### PR TITLE
fix: get_paging 함수 Paramter 전달 개선

### DIFF
--- a/_admin/admin_auth.py
+++ b/_admin/admin_auth.py
@@ -23,7 +23,6 @@ templates.env.globals['get_member_level_select'] = get_member_level_select
 templates.env.globals['subject_sort_link'] = subject_sort_link
 templates.env.globals['get_admin_menus'] = get_admin_menus
 templates.env.globals["generate_one_time_token"] = generate_one_time_token
-templates.env.globals["get_paging"] = get_paging
 templates.env.globals["format"] = format
 
 
@@ -109,7 +108,7 @@ def auth_list(request: Request, db: Session = Depends(get_db), search_params: di
         "total_count": result['total_count'],
         "sum_point": sum_point,
         "auth_options": auth_options,
-        "paging": get_paging(request, search_params['current_page'], result['total_count'], f"/admin/point_list?{query_string(request)}&page="),
+        "paging": get_paging(request, search_params['current_page'], result['total_count']),
     }
     return templates.TemplateResponse("auth_list.html", context)
 

--- a/_admin/admin_board.py
+++ b/_admin/admin_board.py
@@ -23,7 +23,6 @@ templates.env.globals['get_member_level_select'] = get_member_level_select
 templates.env.globals['subject_sort_link'] = subject_sort_link
 templates.env.globals['get_admin_menus'] = get_admin_menus
 templates.env.globals["generate_one_time_token"] = generate_one_time_token
-templates.env.globals["get_paging"] = get_paging
 
 
 @router.get("/board_list")
@@ -73,13 +72,11 @@ def board_list(request: Request, db: Session = Depends(get_db), search_params: d
                 same_search_fields = ["gr_id", "bo_table"], 
             )
     
-    query_string = generate_query_string(request)
-    
     context = {
         "request": request,
         "boards": result['rows'],
         "total_count": result['total_count'],
-        "paging": get_paging(request, search_params['current_page'], result['total_count'], f"/admin/board_list?{query_string}&page="),
+        "paging": get_paging(request, search_params['current_page'], result['total_count']),
     }
     return templates.TemplateResponse("board_list.html", context)
 

--- a/_admin/admin_member.py
+++ b/_admin/admin_member.py
@@ -37,14 +37,12 @@ async def member_list(request: Request, db: Session = Depends(get_db), search_pa
                 prefix_search_fields = ["mb_name", "mb_nick", "mb_tel", "mb_hp", "mb_datetime", "mb_recommend"]
             )
     
-    query_string = generate_query_string(request)
-    
     context = {
         "request": request,
         "members": result['rows'],
         "admin": request.state.login_member, # 로그인해 있는 회원을 관리자로 간주함
         "total_count": result['total_count'],
-        "paging": get_paging(request, search_params['current_page'], result['total_count'], f"/admin/member_list?{query_string}&page="),
+        "paging": get_paging(request, search_params['current_page'], result['total_count']),
     }
     return templates.TemplateResponse("member_list.html", context)
 

--- a/_admin/admin_point.py
+++ b/_admin/admin_point.py
@@ -23,7 +23,6 @@ templates.env.globals['get_member_level_select'] = get_member_level_select
 templates.env.globals['subject_sort_link'] = subject_sort_link
 templates.env.globals['get_admin_menus'] = get_admin_menus
 templates.env.globals["generate_one_time_token"] = generate_one_time_token
-templates.env.globals["get_paging"] = get_paging
 templates.env.globals["format"] = format
 
 
@@ -84,15 +83,13 @@ def point_list(request: Request, db: Session = Depends(get_db), search_params: d
     
     sum_point = db.query(func.sum(Point.po_point)).scalar()
    
-    query_string = generate_query_string(request)
-    
     context = {
         "request": request,
         "config": request.state.config,
         "points": result['rows'],
         "total_count": result['total_count'],
         "sum_point": sum_point,
-        "paging": get_paging(request, search_params['current_page'], result['total_count'], f"/admin/point_list?{query_string}&page="),
+        "paging": get_paging(request, search_params['current_page'], result['total_count']),
     }
     return templates.TemplateResponse("point_list.html", context)
 

--- a/_admin/admin_sendmail.py
+++ b/_admin/admin_sendmail.py
@@ -61,7 +61,6 @@ templates.env.globals['get_member_level_select'] = get_member_level_select
 templates.env.globals['subject_sort_link'] = subject_sort_link
 templates.env.globals['get_admin_menus'] = get_admin_menus
 templates.env.globals["generate_one_time_token"] = generate_one_time_token
-templates.env.globals["get_paging"] = get_paging
 templates.env.globals["domain_mail_host"] = domain_mail_host
 
 

--- a/_admin/admin_visit.py
+++ b/_admin/admin_visit.py
@@ -23,7 +23,6 @@ templates.env.globals['get_member_level_select'] = get_member_level_select
 templates.env.globals['subject_sort_link'] = subject_sort_link
 templates.env.globals['get_admin_menus'] = get_admin_menus
 templates.env.globals["generate_one_time_token"] = generate_one_time_token
-templates.env.globals["get_paging"] = get_paging
 
 VISIT_MENU_KEY = "200800"
 
@@ -43,7 +42,6 @@ async def visit_search(request: Request, db: Session = Depends(get_db),
     # 초기 쿼리 설정
     query = db.query(models.Visit)
     records_per_page = request.state.config.cf_page_rows
-    query_string = generate_query_string(request)
 
     # sod가 제공되면, 해당 열을 기준으로 정렬을 추가합니다.
     if sst is not None and sst != "":
@@ -89,7 +87,7 @@ async def visit_search(request: Request, db: Session = Depends(get_db),
         "request": request,
         "visits": visits,
         "total_records": total_records,
-        "paging": get_paging(request, current_page, total_records, f"/admin/visit_search?{query_string}&page="),
+        "paging": get_paging(request, current_page, total_records),
     }
     return templates.TemplateResponse("visit_search.html", context)
 
@@ -213,13 +211,11 @@ async def visit_list(request: Request, db: Session = Depends(get_db),
     # 전체 레코드 개수 계산
     total_records = query.count()
     
-    query_string = f"fr_date={fr_date}&to_date={to_date}"
-    
     context = {
         "request": request,
         "visits": visits,
         "total_records": total_records,
-        "paging": get_paging(request, current_page, total_records, f"/admin/visit_list?{query_string}&page="),
+        "paging": get_paging(request, current_page, total_records),
         "fr_date": fr_date,
         "to_date": to_date,
     }
@@ -260,13 +256,11 @@ async def visit_domain(request: Request, db: Session = Depends(get_db),
     # 전체 레코드 개수 계산
     total_records = query.count()
     
-    query_string = f"fr_date={fr_date}&to_date={to_date}"
-    
     context = {
         "request": request,
         "visits": visits,
         "total_records": total_records,
-        "paging": get_paging(request, current_page, total_records, f"/admin/visit_list?{query_string}&page="),
+        "paging": get_paging(request, current_page, total_records),
         "fr_date": fr_date,
         "to_date": to_date,
     }

--- a/_admin/templates/visit_search.html
+++ b/_admin/templates/visit_search.html
@@ -10,7 +10,6 @@
 
 <div class="local_sch local_sch01">
     <form name="fvisit" method="get" onsubmit="return fvisit_submit(this);">
-    <?php echo $listall?>
     <label for="sch_sort" class="sound_only">검색분류</label>
     <select name="sfl" id="sch_sort" class="search_sort">
         <option value="vi_ip" {{ get_selected('vi_ip', request.state.sfl if request.state.sfl else '' )}}>IP</option>
@@ -52,15 +51,6 @@
     </tbody>
     </table>
 </div>
-
-<?php
-$domain = isset($domain) ? $domain : '';
-$pagelist = get_paging($config['cf_write_pages'], $page, $total_page, $_SERVER['SCRIPT_NAME'].'?'.$qstr.'&amp;domain='.$domain.'&amp;page=');
-if ($pagelist) {
-    echo $pagelist;
-}
-?>
-
 <script>
 $(function(){
     $("#sch_sort").change(function(){ // select #sch_sort의 옵션이 바뀔때

--- a/_bbs/memo.py
+++ b/_bbs/memo.py
@@ -54,7 +54,7 @@ def memo_list(request: Request, db: Session = Depends(get_db),
         "memos": memos,
         "total_records": total_records,
         "page": current_page,
-        "paging": get_paging(request, current_page, total_records, f"/memo/list?kind={ kind }&page="),
+        "paging": get_paging(request, current_page, total_records),
     }
     
     return templates.TemplateResponse(f"memo/{request.state.device}/memo_list.html", context)

--- a/_bbs/qa.py
+++ b/_bbs/qa.py
@@ -83,7 +83,7 @@ def qa_list(request: Request,
         "categories": qa_config.qa_category.split("|"),
         "total_records": total_records,
         "current_page": current_page,
-        "paging": get_paging(request, current_page, total_records, f"/qa/list?{generate_query_string(request)}&page="),
+        "paging": get_paging(request, current_page, total_records),
     }
 
     return templates.TemplateResponse(f"qa/pc/qa_list.html", context)

--- a/common.py
+++ b/common.py
@@ -497,10 +497,10 @@ def get_from_list(lst, index, default=0):
 
 # current_page : 현재 페이지
 # total_count : 전체 레코드 수
-# url_prefix : 페이지 링크의 URL 접두사
 # add_url : 페이지 링크의 추가 URL
-def get_paging(request, current_page, total_count, url_prefix, add_url=""):
+def get_paging(request: Request, current_page, total_count, add_url=""):
     config = request.state.config
+    url_prefix = request.url
     
     try:
         current_page = int(current_page)
@@ -532,18 +532,18 @@ def get_paging(request, current_page, total_count, url_prefix, add_url=""):
     
     # 처음 페이지 링크 생성
     if current_page > 1:
-        start_url = f"{url_prefix}1{add_url}"
+        start_url = f"{url_prefix.include_query_params(page=1)}{add_url}"
         page_links.append(f'<a href="{start_url}" class="pg_page pg_start" title="처음 페이지">처음</a>')
 
     # 이전 페이지 구간 링크 생성
     if start_page > 1:
         prev_page = max(current_page - page_count, 1) 
-        prev_url = f"{url_prefix}{prev_page}{add_url}"
+        prev_url = f"{url_prefix.include_query_params(page=prev_page)}{add_url}"
         page_links.append(f'<a href="{prev_url}" class="pg_page pg_prev" title="이전 구간">이전</a>')
 
     # 페이지 링크 생성
     for page in range(start_page, end_page + 1):
-        page_url = f"{url_prefix}{page}{add_url}"
+        page_url = f"{url_prefix.include_query_params(page=page)}{add_url}"
         if page == current_page:
             page_links.append(f'<a href="{page_url}"><strong class="pg_current" title="현재 {page} 페이지">{page}</strong></a>')
         else:
@@ -552,12 +552,12 @@ def get_paging(request, current_page, total_count, url_prefix, add_url=""):
     # 다음 페이지 구간 링크 생성
     if total_pages > end_page:
         next_page = min(current_page + page_count, total_pages)
-        next_url = f"{url_prefix}{next_page}{add_url}"
+        next_url = f"{url_prefix.include_query_params(page=next_page)}{add_url}"
         page_links.append(f'<a href="{next_url}" class="pg_page pg_next" title="다음 구간">다음</a>')
     
     # 마지막 페이지 링크 생성        
     if current_page < total_pages:
-        end_url = f"{url_prefix}{total_pages}{add_url}"
+        end_url = f"{url_prefix.include_query_params(page=total_pages)}{add_url}"
         page_links.append(f'<a href="{end_url}" class="pg_page pg_end" title="마지막 페이지">마지막</a>')
 
     # 페이지 링크 목록을 문자열로 변환하여 반환


### PR DESCRIPTION
### 작업 내역
#### 1. `get_paging` 함수 > `url_prefix ` Parameter 삭제
   - `get_paging` 함수 사용 시, url_prefix를 전달해야 하는 번거로움 해결
   - `request.url.include_query_params` 를 활용, 현재 URL에서 page 값만 갱신한다. (query_string 병합기능)
#### 2. 사용하지 않는 코드 삭제
   - `template.env` > get_paging 전달 삭제
   - `visit_search.html` > php코드 삭제