### PR TITLE
fix: setup.py 설치오류 수정

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,7 @@ def board_group_setup():
     
     exists_board_group = db.query(models.Group).filter_by(gr_id=default_gr_id).first()
     if exists_board_group is None:
-        new_board_group = models.Group(gr_id='community', gr_subject='커뮤니티')
+        new_board_group = models.Group(gr_id=default_gr_id, gr_subject='커뮤니티')
         try:
             db.add(new_board_group)
             db.commit()
@@ -254,6 +254,7 @@ def board_setup():
         if exists_board is None:
             new_board = models.Board(
                 bo_table=bo_table,
+                gr_id=default_gr_id,
                 bo_subject=bo_subject,
                 bo_skin=bo_skin,
                 bo_mobile_skin=bo_skin,


### PR DESCRIPTION
### 원인
- `Board` 모델의 `gr_id`의 외래키 설정으로 인해 default=""로 입력이 불가능. (`Group`의 `gr_id` 값만 입력 가능)
### 해결 및 작업내역
- `setup.py` > board_setup 함수 > Board 생성시 누락된 gr_id값을 추가해주므로 해결 (default_gr_id)
