### PR TITLE
fix: 투표 기능 토큰 중복으로 인한 오류 수정

### DIFF
--- a/_bbs/poll.py
+++ b/_bbs/poll.py
@@ -25,6 +25,9 @@ def poll_update(request: Request, po_id: int, token: str = Form(...), gb_poll: i
     """
     투표하기
     """
+    if not check_token(request, token):
+        raise AlertException("토큰이 유효하지 않습니다.", 403)
+
     poll = db.query(Poll).get(po_id)
     member = request.state.login_member
     member_level = get_member_level(request)
@@ -34,24 +37,21 @@ def poll_update(request: Request, po_id: int, token: str = Form(...), gb_poll: i
 
     if poll.po_level > 1 and member_level < poll.po_level:
         raise AlertCloseException(status_code=403, detail=f"권한 {poll.po_level} 이상의 회원만 투표하실 수 있습니다.")
+    
+    if request.client.host in poll.po_ips or (member and member.mb_id in poll.mb_ids):
+        raise AlertException(status_code=403, detail=f"{poll.po_subject} 투표에 이미 참여하셨습니다.", url=f"/bbs/poll_result/{po_id}")
 
-    if compare_token(request, token, "update"):
-        if request.client.host in poll.po_ips or (member and member.mb_id in poll.mb_ids):
-            raise AlertException(status_code=403, detail=f"{poll.po_subject} 투표에 이미 참여하셨습니다.", url=f"/bbs/poll_result/{po_id}")
-
-        if member:
-            poll.mb_ids = ",".join([poll.mb_ids, member.mb_id]) if poll.mb_ids else member.mb_id
-        else:
-            poll.po_ips = ",".join([poll.po_ips, request.client.host]) if poll.po_ips else request.client.host
-        
-        # gb_poll로 전달받은 컬럼번호에 1 증가시킨다.
-        poll.__setattr__(f"po_cnt{gb_poll}", poll.__getattribute__(f"po_cnt{gb_poll}") + 1)
-        db.commit()
-
-        # 포인트 지급
-        insert_point(request, member.mb_id, poll.po_point,  f'{poll.po_id}. {poll.po_subject[:20]} 투표 참여 ', '@poll', poll.po_id, '투표');
+    if member:
+        poll.mb_ids = ",".join([poll.mb_ids, member.mb_id]) if poll.mb_ids else member.mb_id
     else:
-        raise AlertException(status_code=403, detail=f"{token} : 토큰이 유효하지 않습니다. 새로고침후 다시 시도해 주세요.")
+        poll.po_ips = ",".join([poll.po_ips, request.client.host]) if poll.po_ips else request.client.host
+    
+    # gb_poll로 전달받은 컬럼번호에 1 증가시킨다.
+    poll.__setattr__(f"po_cnt{gb_poll}", poll.__getattribute__(f"po_cnt{gb_poll}") + 1)
+    db.commit()
+
+    # 포인트 지급
+    insert_point(request, member.mb_id, poll.po_point,  f'{poll.po_id}. {poll.po_subject[:20]} 투표 참여 ', '@poll', poll.po_id, '투표');
 
     return RedirectResponse(url=f"/bbs/poll_result/{po_id}", status_code=302)
       
@@ -110,36 +110,36 @@ def poll_etc_update(request: Request,
     """
     기타의견 등록
     """
+    if not check_token(request, token):
+        raise AlertException(f"{token} : 토큰이 유효하지 않습니다. 새로고침후 다시 시도해 주세요.", 403)
+
     poll = db.query(Poll).get(po_id)
     config = request.state.config
     member = request.state.login_member
     member_level = get_member_level(request)
 
-    if compare_token(request, token, "insert"):
-        if poll.po_level > member_level:
-            raise AlertCloseException(f"권한 {poll.po_level} 이상의 회원만 기타의견을 등록할 수 있습니다.", 403)
+    if poll.po_level > member_level:
+        raise AlertCloseException(f"권한 {poll.po_level} 이상의 회원만 기타의견을 등록할 수 있습니다.", 403)
 
-        po_etc = PollEtc(po_id=po_id, pc_name=pc_name, pc_idea=pc_idea, mb_id=(member.mb_id if member else ''))
-        db.add(po_etc)
-        db.commit()
+    po_etc = PollEtc(po_id=po_id, pc_name=pc_name, pc_idea=pc_idea, mb_id=(member.mb_id if member else ''))
+    db.add(po_etc)
+    db.commit()
 
-        # 최고관리자 메일 발송 설정이 되어있으면 메일 발송
-        if config.cf_email_po_super_admin:
-            if config.cf_admin_email:
-                email = config.cf_admin_email
-                subject = f"[{config.cf_title}] 설문조사 - ({poll.po_subject}) 기타의견 메일"
-                body = templates.TemplateResponse(
-                    "bbs/mail_form/poll_etc_update_mail.html", {
-                        "request": request,
-                        "subject": subject,
-                        "mb_name": pc_name,
-                        "mb_id": member.mb_id if member else '비회원',
-                        "content": pc_idea
-                    }
-                ).body.decode("utf-8")
-                mailer(email, subject, body)
-    else:
-        raise AlertException(f"{token} : 토큰이 유효하지 않습니다. 새로고침후 다시 시도해 주세요.", 403)
+    # 최고관리자 메일 발송 설정이 되어있으면 메일 발송
+    if config.cf_email_po_super_admin:
+        if config.cf_admin_email:
+            email = config.cf_admin_email
+            subject = f"[{config.cf_title}] 설문조사 - ({poll.po_subject}) 기타의견 메일"
+            body = templates.TemplateResponse(
+                "bbs/mail_form/poll_etc_update_mail.html", {
+                    "request": request,
+                    "subject": subject,
+                    "mb_name": pc_name,
+                    "mb_id": member.mb_id if member else '비회원',
+                    "content": pc_idea
+                }
+            ).body.decode("utf-8")
+            mailer(email, subject, body)
 
     return RedirectResponse(url=f"/bbs/poll_result/{po_id}", status_code=302)
 
@@ -149,18 +149,18 @@ def poll_etc_delete(request: Request, pc_id: int, token: str, db: Session = Depe
     """
     기타의견 삭제
     """
+    if compare_token(request, token, "poll_etc_delete"):
+        raise AlertException(f"{token} : 토큰이 유효하지 않습니다. 새로고침후 다시 시도해 주세요.", 403)
+    
     poll_etc = db.query(PollEtc).get(pc_id)
     po_id = poll_etc.po_id
     member = request.state.login_member
     member_level = get_member_level(request)
 
-    if compare_token(request, token, "delete"):
-        if poll_etc.mb_id != member.mb_id and not member_level == 10:
-            raise AlertException(status_code=403, detail=f"작성자만 삭제할 수 있습니다.")
+    if poll_etc.mb_id != member.mb_id and not member_level == 10:
+        raise AlertException(status_code=403, detail=f"작성자만 삭제할 수 있습니다.")
 
-        db.delete(poll_etc)
-        db.commit()
-    else:
-        raise AlertException(status_code=403, detail=f"{token} : 토큰이 유효하지 않습니다. 새로고침후 다시 시도해 주세요.")
-
+    db.delete(poll_etc)
+    db.commit()
+        
     return RedirectResponse(url=f"/bbs/poll_result/{po_id}", status_code=302)

--- a/templates/basic/bbs/poll.html
+++ b/templates/basic/bbs/poll.html
@@ -2,7 +2,7 @@
     <form name="fpoll" action="{{ url_for('poll_update', po_id=poll.po_id) }}" onsubmit="return fpoll_submit(this);" method="post" target="win_poll">
         <input type="hidden" name="po_id" value="{{ poll.po_id }}">
         <input type="hidden" name="skin_dir" value="theme%2Fbasic">
-        <input type="hidden" name="token" value="{{ generate_token(request, 'update') }}">
+        <input type="hidden" name="token" value="">
         <section id="poll">
             <header>
                 <h2>설문조사</h2>
@@ -47,6 +47,12 @@
         
             if (!chk) {
                 alert("투표하실 설문항목을 선택하세요");
+                return false;
+            }
+
+            f.token.value = generate_token();
+            if (f.token.value == "") {
+                alert("토큰값이 없습니다.");
                 return false;
             }
         

--- a/templates/basic/bbs/poll_result.html
+++ b/templates/basic/bbs/poll_result.html
@@ -37,7 +37,7 @@
             {% if poll.po_etc %}
                 <section id="poll_result_cmt">
                     <h2>이 설문에 대한 기타의견</h2>
-                    {% set delete_token=generate_token(request, 'delete') %}
+                    {% set delete_token=generate_token(request, 'poll_etc_delete') %}
                     {% for etc in etcs %}
                         <article>
                             <header>
@@ -58,7 +58,7 @@
                     {% endfor %}
                     {% if get_member_level(request) >= poll.po_level %}
                         <form name="fpollresult" action="{{ url_for('poll_etc_update', po_id=poll.po_id) }}" onsubmit="return fpollresult_submit(this);" method="post" autocomplete="off" id="poll_other_q">
-                            <input type="hidden" name="token" value="{{ generate_token(request, 'insert') }}">
+                            <input type="hidden" name="token" value="">
                             <input type="hidden" name="skin_dir" value="theme%2Fbasic">
                             {% if request.state.login_member.mb_id %}
                                 <input type="hidden" name="pc_name" value="{{ request.state.login_member.mb_nick }}">
@@ -117,6 +117,12 @@
     
     function fpollresult_submit(f)
     {
+        f.token.value = generate_token();
+        if (f.token.value == "") {
+            alert("토큰값이 없습니다.");
+            return false;
+        }
+
         return true;
     }
     </script>


### PR DESCRIPTION
### 원인 및 해결방안
#### 1. `generate_token()` 함수의 토큰 중복 생성으로 세션의 `ss_token` 값이 갱신되어 기능이 정상 동작하지 않음
- form을 submit 할 때, 토큰을 생성해서 전달한다.
- `common.js` > `generate_token()` 함수를 사용
#### 2. `generate_token(request, action)` 에서 action 중복으로 인해 세션의 `ss_token` 값이 갱신되어 기능이 정상 동작하지 않음
- `action` 값을 기능별로 유일하게 할당한다.

### 작업내역
- 우측 투표하기 > 토큰 중복 생성으로 인한 오류 수정
- 투표 결과 > 기타의견 등록/삭제 토큰 중복으로 인한 오류 수정

※ 나머지 기능들도 순차적으로 고쳐나가야 한다.
