### PR TITLE
#103 [fix] 답글/댓글 답변오류 수정

### DIFF
--- a/install.py
+++ b/install.py
@@ -296,7 +296,7 @@ def board_setup():
                 bo_upload_size=10485760,
                 bo_reply_order='1',
                 bo_comment_level=1,
-                bo_sort_field='wr_datetime',
+                bo_sort_field='',
                 bo_table_width=100,
                 bo_1_subj='',
                 bo_2_subj='',

--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -870,35 +870,40 @@ def generate_reply_character(board: Board, write):
     # 마지막 문자열 1개 자르기
     if not write.wr_is_comment:
         origin_reply = write.wr_reply
-        query = db.query(func.right(write_model.wr_reply, 1).label("reply")).filter(
-            write_model.wr_num == write.wr_num,
-            func.length(write_model.wr_reply) == (len(origin_reply) + 1)
+        query = (
+            select(func.substr(write_model.wr_reply, -1).label("reply"))
+            .where(
+                write_model.wr_num == write.wr_num,
+                func.length(write_model.wr_reply) == (len(origin_reply) + 1)
+            )
         )
         if origin_reply:
-            query = query.filter(write_model.wr_reply.like(f"{origin_reply}%"))
+            query = query.where(write_model.wr_reply.like(f"{origin_reply}%"))
     else:
         origin_reply = write.wr_comment_reply
-        query = db.query(func.right(write_model.wr_comment_reply, 1).label("reply")).filter(
-            write_model.wr_parent == write.wr_parent,
-            write_model.wr_comment == write.wr_comment,
-            func.length(write_model.wr_comment_reply) == (len(origin_reply) + 1)
+        query = (
+            select(func.substr(write_model.wr_comment_reply, -1).label("reply"))
+            .where(
+                write_model.wr_parent == write.wr_parent,
+                write_model.wr_comment == write.wr_comment,
+                func.length(write_model.wr_comment_reply) == (len(origin_reply) + 1)
+            )
         )
         if origin_reply:
-            query = query.filter(write_model.wr_comment_reply.like(f"{origin_reply}%"))
+            query = query.where(write_model.wr_comment_reply.like(f"{origin_reply}%"))
 
     # 정방향이면 최대값, 역방향이면 최소값
     if board.bo_reply_order:
-        result = query.order_by(desc("reply")).first()
+        last_reply_char = db.scalar(query.order_by(desc("reply")))
         char_begin = "A"
         char_end = "Z"
         char_increase = 1
     else:
-        result = query.order_by(asc("reply")).first()
+        last_reply_char = db.scalar(query.order_by(asc("reply")))
         char_begin = "Z"
         char_end = "A"
         char_increase = -1
 
-    last_reply_char = result.reply if result else None
     if last_reply_char == char_end:  # A~Z은 26 입니다.
         raise AlertException("더 이상 답변하실 수 없습니다. 답변은 26개 까지만 가능합니다.")
 


### PR DESCRIPTION
### 원인
- MYSQL의 `right` 함수가 다른 데이터베이스에서는 지원하지 않아서 Query 오류 발생
   - SQLite, Oracle
### 작업내용
#### 1. `right` => `substr` 변경
#### 2. SQLAlchemy 2.0 표현식으로 변경
#### 3. 추가 > 처음 설치 후 답글 작성 시, 정렬이 제대로 되지 않아보이는 현상
- 기본 설치시, 게시판 정렬 기본값 변경
- `wr_datetime` => ""