### PR TITLE
#106 [fix] 새글 테이블에 댓글이 등록되지 않는 오류 수정

### DIFF
--- a/bbs/board.py
+++ b/bbs/board.py
@@ -1151,6 +1151,9 @@ async def write_comment_update(
         write.wr_comment = write.wr_comment + 1
         db.commit()
 
+        # 새글 추가
+        insert_board_new(form.bo_table, comment)
+
         # 메일 발송
         if board_config.use_email:
             send_write_mail(request, board, comment, write)

--- a/bbs/board_new.py
+++ b/bbs/board_new.py
@@ -51,9 +51,10 @@ async def board_new_list(
             # 댓글/게시글 구분
             if write.wr_is_comment:
                 new.subject = "[댓글] " + write.wr_content[:100]
-                new.add_link = f"#c_{write.wr_id}"
+                new.link = f"/board/{new.bo_table}/{new.wr_parent}#c_{write.wr_id}"
             else:
                 new.subject = write.wr_subject
+                new.link = f"/board/{new.bo_table}/{new.wr_id}"
 
             # 작성자
             new.name = cut_name(request, write.wr_name)

--- a/lib/common.py
+++ b/lib/common.py
@@ -1943,7 +1943,7 @@ def datetime_format(date: datetime, format="%Y-%m-%d %H:%M:%S"):
     return date.strftime(format)
 
 
-def insert_board_new(bo_table: str, write: object):
+def insert_board_new(bo_table: str, write: WriteBaseModel):
     """
     최신글 테이블 등록 함수
     """

--- a/templates/basic/new/basic/new_list.html
+++ b/templates/basic/new/basic/new_list.html
@@ -88,7 +88,7 @@
                         <a href="/board/{{ board_new.bo_table }}">{{ board.bo_subject }}</a>
                     </td>
                     <td>
-                        <a href="/board/{{ board_new.bo_table }}/{{ board_new.wr_id }}{{ board_new.add_link }}" class="new_tit">{{ board_new.subject }}</a>
+                        <a href="{{ board_new.link }}" class="new_tit">{{ board_new.subject }}</a>
                     </td>
                     <td class="td_name">{{ board_new.name }}</td>
                     <td class="td_date">{{ board_new.datetime }}</td>


### PR DESCRIPTION
### 원인 
- 새글 테이블 입력 프로세스 누락

### 작업내용
- 댓글 등록 시, `insert_board_new` 함수 실행 추가

### 기타 작업내용
- 새글 > 댓글 링크가 게시글로 이동되는 오류 수정
- `insert_board_new` 함수 타입힌트 수정