### PR TITLE
[fix] 게시판 비밀댓글 미선택시 발생 오류 수정

### DIFF
--- a/bbs/board.py
+++ b/bbs/board.py
@@ -1220,7 +1220,7 @@ async def write_comment_update(
             raise AlertException(f"{form.comment_id} : 존재하지 않는 댓글입니다.", 404)
 
         comment.wr_content = form.wr_content
-        comment.wr_option = form.wr_secret
+        comment.wr_option = form.wr_secret or "html1"
         comment.wr_last = datetime.now()
         db.commit()
 


### PR DESCRIPTION
비밀댓글 미선택하고 댓글 수정시에 NotNullViolation 에러 발생
댓글 수정시 wr_option 값이 'secret', 'html1' 중 하나가 되도록 수정