### PR TITLE
#145 fix: templates/{theme}/moible 폴더가 없을 경우 get_skin_select 함수 내 오류 수정

### DIFF
--- a/admin/templates/board_form.html
+++ b/admin/templates/board_form.html
@@ -682,7 +682,7 @@
             <tr>
             <th scope="row"><label for="bo_skin">스킨 디렉토리<strong class="sound_only">필수</strong></label></th>
             <td>
-                {{ get_skin_select('board', 'bo_skin', board.bo_skin, event='required', device='')|safe }}
+                {{ get_skin_select('board', 'bo_skin', board.bo_skin, attribute='required')|safe }}
             </td>
             <td class="td_grpset">
                 <input type="checkbox" name="chk_grp_skin" id="chk_grp_skin">
@@ -694,7 +694,7 @@
         <tr>
             <th scope="row"><label for="bo_mobile_skin">모바일<br>스킨 디렉토리<strong class="sound_only">필수</strong></label></th>
             <td>
-                {{ get_skin_select('board', 'bo_mobile_skin', board.bo_mobile_skin, event='required', device='mobile')|safe }}
+                {{ get_skin_select('board', 'bo_mobile_skin', board.bo_mobile_skin, device='mobile')|safe }}
             </td>
             <td class="td_grpset">
                 <input type="checkbox" name="chk_grp_mobile_skin" id="chk_grp_mobile_skin">

--- a/admin/templates/board_list.html
+++ b/admin/templates/board_list.html
@@ -64,11 +64,11 @@
                         </td>
                         <td>
                             <label for="bo_skin[{{ loop.index0 }}]" class="sound_only">스킨</label>
-                            {{ get_skin_select('board', 'bo_skin[]', board.bo_skin, event='required', device='')|safe }}
+                            {{ get_skin_select('board', 'bo_skin[]', board.bo_skin, attribute='required')|safe }}
                         </td>
                         <td>
                             <label for="bo_mobile_skin[]" class="sound_only">모바일 스킨</label>
-                            {{ get_skin_select('board', 'bo_mobile_skin[]', board.bo_mobile_skin, event='required', device='mobile')|safe }}
+                            {{ get_skin_select('board', 'bo_mobile_skin[]', board.bo_mobile_skin, device='mobile')|safe }}
                         </td>
                         <td>
                             <label for="bo_subject_{{ loop.index0 }}" class="sound_only">게시판 제목<strong class="sound_only"> 필수</strong></label>

--- a/admin/templates/content_form.html
+++ b/admin/templates/content_form.html
@@ -49,13 +49,13 @@
                 <tr>
                     <th scope="row"><label for="co_skin">스킨 디렉토리<strong class="sound_only">필수</strong></label></th>
                     <td>
-                        {{ get_skin_select('content', 'co_skin', content.co_skin, event='', device='')|safe }}
+                        {{ get_skin_select('content', 'co_skin', content.co_skin)|safe }}
                     </td>
                 </tr>
                 <tr>
                     <th scope="row"><label for="co_mobile_skin">모바일스킨 디렉토리<strong class="sound_only">필수</strong></label></th>
                     <td>
-                        {{ get_skin_select('content', 'co_mobile_skin', content.co_mobile_skin, event='', device='mobile')|safe }}
+                        {{ get_skin_select('content', 'co_mobile_skin', content.co_mobile_skin, device='mobile')|safe }}
                     </td>
                 </tr>
                 <!--

--- a/lib/common.py
+++ b/lib/common.py
@@ -171,19 +171,36 @@ def get_member_level_select(id: str, start: int, end: int, selected: int, event=
     html_code.append('</select>')
     return ''.join(html_code)
 
-    
-# skin_gubun(new, search, connect, faq 등) 에 따른 스킨을 SELECT 형식으로 얻음
-def get_skin_select(skin_gubun, id, selected, event='', device=''):
+
+def get_skin_select(skin_gubun: str, id: str, selected: str,
+                    attribute: str = "", device: str = "") -> str:
+    """skin_gubun(new, search, connect, faq 등)에 따른 스킨을
+    SELECT 형식으로 얻음
+
+    Args:
+        skin_gubun (str): 테마 내부의 폴더명(기능)
+        id (str): select 태그의 id 속성값
+        selected (str): 기본적으로 선택되어야 할 스킨명
+        attribute (str, optional): select 태그의 추가 속성값. Defaults to "".
+        device (str, optional): 디바이스별 폴더명(mobile). Defaults to "".
+            PC는 추가 경로 없음 (ex: /template/{theme}/board/{skin_gubun})
+
+    Returns:
+        str: select 태그의 HTML 코드
+    """
     skin_path = TEMPLATES_DIR + f"/{device}/{skin_gubun}"
 
     html_code = []
-    html_code.append(f'<select id="{id}" name="{id}" {event}>')
-    html_code.append(f'<option value="">선택</option>')
-    for skin in os.listdir(skin_path):
-        # print(f"{skin_path}/{skin}")
+    html_code.append(f'<select id="{id}" name="{id}" {attribute}>')
+    html_code.append('<option value="">선택</option>')
+
+    for skin in os.listdir(skin_path) if os.path.isdir(skin_path) else []:
         if os.path.isdir(f"{skin_path}/{skin}"):
-            html_code.append(f'<option value="{skin}" {"selected" if skin == selected else ""}>{skin}</option>')
+            attr = "selected" if skin == selected else ""
+            html_code.append(f'<option value="{skin}" {attr}>{skin}</option>')
+
     html_code.append('</select>')
+
     return ''.join(html_code)
 
 


### PR DESCRIPTION
### 원인
- mobile 하위 경로 삭제로 인해 스킨을 찾을 수 없음.

### 작업내용
- {theme}/moible/{skin_gubun} 폴더를 체크하는 if문 추가
- 매개변수 이름을 적절한 의미를 가지도록 수정 (event => attribute)
- 주석&타입 힌팅 추가, 코드스타일 수정
