### PR TITLE
 #162  [fix] DB 호환 관련 오류 수정> SQLite Date Column

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -44,7 +44,7 @@ EDITOR_PATH = "lib/editor/templates"
 # 나중에 삭제할 코드
 SERVER_TIME = datetime.now()
 TIME_YMDHIS = SERVER_TIME.strftime("%Y-%m-%d %H:%M:%S")
-TIME_YMD = TIME_YMDHIS[:10]
+TIME_YMD = SERVER_TIME
 
 
 def hash_password(password: str):


### PR DESCRIPTION
SQLite는 Date type column에 대해서 Python date object만 허용
PostgreSQL, MySQL은 date를 string 포맷으로 입력해도 오류 발생하지 않음

SQLite의 Date Column에 String 타입의 컬럼 값을 넣으면서 발생하는 오류 수정