### PR TITLE
#170 feat: 사용자가 PC/모바일버전을 선택할 수 있도록 추가

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -17,16 +17,6 @@ def regist_core_middleware(app: FastAPI) -> None:
     미들웨어의 실행 순서는 코드의 역순으로 실행됩니다.
     - main.py의 main_middleware()보다 먼저 실행됩니다.
     """
-    # 세션 미들웨어를 추가합니다.
-    # .env 파일의 설정을 통해 secret_key, session_cookie를 설정할 수 있습니다.
-    app.add_middleware(SessionMiddleware,
-                   secret_key=os.getenv("SESSION_SECRET_KEY", "secret"),
-                   session_cookie=os.getenv("SESSION_COOKIE_NAME", "session"),
-                   max_age=60 * 60 * 3)
-
-    # 모든 들어오는 요청을 HTTPS로 리디렉션하는 미들웨어를 추가합니다.
-    app.add_middleware(HTTPSRedirectMiddleware)
-
     # 기본으로 실행되는 core 미들웨어를 추가합니다.
     @app.middleware("http")
     async def core_middleware(request: Request, call_next):
@@ -48,22 +38,38 @@ def regist_core_middleware(app: FastAPI) -> None:
             cache_plugin_menu.__setitem__('admin_menus', register_plugin_admin_menu(new_plugin_state))
             cache_plugin_state.__setitem__('change_time', plugin_state_change_time)
 
+        # 적응형 여부 설정
+        request.state.is_responsive = TemplateService.get_responsive()
+
         # 모바일 여부 설정
         request.state.is_mobile = False
-        
-        user_agent = request.headers.get("User-Agent", "")
-        ua = parse(user_agent)
-        # 모바일과 태블릿에서 접속하면 모바일로 간주
-        if ua.is_mobile or ua.is_tablet:
-            request.state.is_mobile = True
+        # 사용자의 PC/모바일 버전 설정이 있는지 세션에서 확인합니다.
+        if not request.session.get("is_mobile"):
+            # User-Agent 헤더를 통해 모바일 여부를 판단합니다.
+            # 모바일과 태블릿에서 접속하면 모바일로 간주
+            user_agent = parse(request.headers.get("User-Agent", ""))
+            if user_agent.is_mobile or user_agent.is_tablet:
+                request.state.is_mobile = True
+        else:
+            request.state.is_mobile = request.session.get("is_mobile", False)
 
-        # 디바이스 기본값을 설정합니다.
+        # 디바이스 기본값 설정
         # 반응형이 아니라면 모바일 접속은 mobile로, 그 외 접속은 PC로 간주합니다.
         request.state.device = "pc"
-        if not TemplateService.get_responsive() and request.state.is_mobile:
+        if not request.state.is_responsive and request.state.is_mobile:
             request.state.device = "mobile"
 
         return await call_next(request)
+
+    # 세션 미들웨어를 추가합니다.
+    # .env 파일의 설정을 통해 secret_key, session_cookie를 설정할 수 있습니다.
+    app.add_middleware(SessionMiddleware,
+                   secret_key=os.getenv("SESSION_SECRET_KEY", "secret"),
+                   session_cookie=os.getenv("SESSION_COOKIE_NAME", "session"),
+                   max_age=60 * 60 * 3)
+
+    # 모든 들어오는 요청을 HTTPS로 리디렉션하는 미들웨어를 추가합니다.
+    app.add_middleware(HTTPSRedirectMiddleware)
 
 
 async def should_run_middleware(request: Request) -> bool:
@@ -79,9 +85,9 @@ async def should_run_middleware(request: Request) -> bool:
     Returns:
         bool: 미들웨어를 실행할지 여부
     """
-
     path = request.url.path
     if (path.startswith('/generate_token')
+            or path.startswith('/device/change')
             or path.startswith('/static')
             or path.endswith(('.css', '.js', '.jpg', '.png', '.gif', '.webp'))):
         return False

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 import datetime
 
 from apscheduler.schedulers.background import BackgroundScheduler
-from fastapi import FastAPI, Request, Response
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import FastAPI, Path, Request, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import TypeAdapter
 from sqlalchemy import select, inspect
 from starlette.staticfiles import StaticFiles
@@ -282,8 +282,42 @@ async def index(request: Request, db: db_session):
 
 
 @app.post("/generate_token")
-async def generate_token(request: Request):
+async def generate_token(request: Request) -> JSONResponse:
+    """세션 토큰 생성 후 반환
 
+    Args:
+        request (Request): FastAPI의 Request 객체
+
+    Returns:
+        JSONResponse: 성공 여부와 토큰을 포함한 JSON 응답
+    """
     token = create_session_token(request)
 
     return JSONResponse(content={"success": True, "token": token})
+
+
+@app.get("/device/change/{device}")
+async def device_change(
+    request: Request,
+    device: str = Path(...)
+) -> RedirectResponse:
+    """접속환경(디바이스) 변경
+    - PC/모바일 버전을 강제로 변경합니다.
+
+    Args:
+        request (Request): FastAPI의 Request 객체
+        device (str, optional): 변경할 디바이스. Defaults to Path(...).
+
+    Returns:
+        RedirectResponse: 이전 페이지로 리디렉션
+    """
+    if device not in ["pc", "mobile"]:
+        raise AlertException("잘못된 접근입니다.", 400, "/")
+
+    if device == "pc":
+        request.session["is_mobile"] = False
+    else:
+        request.session["is_mobile"] = True
+
+    referer = request.headers.get("Referer", "/")
+    return RedirectResponse(referer, status_code=303)

--- a/templates/basic/base.html
+++ b/templates/basic/base.html
@@ -138,7 +138,14 @@
             <a href="{{ url_for('content_view', co_id='company') }}">회사소개</a>
             <a href="{{ url_for('content_view', co_id='privacy') }}">개인정보처리방침</a>
             <a href="{{ url_for('content_view', co_id='provision') }}">서비스이용약관</a>
-            <a href="/?device=mobile">모바일버전</a>
+
+            {% if not request.state.is_responsive %}
+                {% if request.state.is_mobile %}
+                    <a href="{{ url_for('device_change', device='pc') }}">PC버전</a>
+                {% else %}
+                    <a href="{{ url_for('device_change', device='mobile') }}">모바일버전</a>
+                {% endif %}
+            {% endif %}
         </div>
         <div id="ft_company" class="ft_cnt">
         	<h2>사이트 정보</h2>


### PR DESCRIPTION
### 작업내용
#### `.env` > `IS_RESPONSIVE`(적응형 설정)이 False 일 때, PC/모바일버전 선택버튼이 하단에 표시
- 다시 고민해보니 `IS_RESPONSIVE` 값에 상관없이 사용자가 버전을 변경하는 것은 관리자의 의도와는 다를 수 있으므로 제한을 걸었습니다.
   - https://github.com/gnuboard/gnu6/issues/170#issuecomment-1876453439
<pre><code>
# 웹사이트 표시 방법 (반드시 문자열로 입력해야 합니다)
# "True" (기본값) : 반응형 웹사이트 (참고: 반응형 템플릿만 제공합니다.)
# "False" : 적응형 웹사이트
IS_RESPONSIVE = "False"
</code></pre>
#### 버튼을 통해 강제로 접속 버전을 변경 할 수 있도록 기능 추가
- PC버전
![PC](https://github.com/gnuboard/gnu6/assets/57935683/ac141375-1bb0-458f-afb5-ecdad973d88e)
- 모바일버전
![모바일](https://github.com/gnuboard/gnu6/assets/57935683/5c0bfaa0-db9b-4007-a53a-811e1fa9aabc)