### PR TITLE
[fix] 메인페이지 > 최신글 PC/Mobile 구분

### DIFF
--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -1322,12 +1322,13 @@ def insert_board_new(bo_table: str, write: WriteBaseModel) -> None:
     db.close()
 
 
-def render_latest_posts(request: Request, skin_dir='', bo_table='', rows=10, subject_len=40):
+def render_latest_posts(request: Request, skin_name: str = 'basic', bo_table: str='',
+                        rows: int = 10, subject_len: int = 40):
     """최신글 목록 HTML 출력
 
     Args:
         request (Request): _description_
-        skin_dir (str, optional): 스킨 경로. Defaults to ''.
+        skin_name (str, optional): 스킨 경로. Defaults to ''.
         bo_table (str, optional): 게시판 코드. Defaults to ''.
         rows (int, optional): 노출 게시글 수. Defaults to 10.
         subject_len (int, optional): 제목길이 제한. Defaults to 40.
@@ -1338,11 +1339,9 @@ def render_latest_posts(request: Request, skin_dir='', bo_table='', rows=10, sub
     templates = UserTemplates()
     templates.env.globals["get_list_thumbnail"] = get_list_thumbnail
 
-    if not skin_dir:
-        skin_dir = 'basic'
-
+    device = request.state.device
     file_cache = FileCache()
-    cache_filename = f"latest-{bo_table}-{skin_dir}-{rows}-{subject_len}-{file_cache.get_cache_secret_key()}.html"
+    cache_filename = f"latest-{bo_table}-{device}-{skin_name}-{rows}-{subject_len}-{file_cache.get_cache_secret_key()}.html"
     cache_file = os.path.join(file_cache.cache_dir, cache_filename)
 
     # 캐시된 파일이 있으면 파일을 읽어서 반환
@@ -1372,7 +1371,7 @@ def render_latest_posts(request: Request, skin_dir='', bo_table='', rows=10, sub
         "writes": writes,
         "bo_table": bo_table,
     }
-    temp = templates.TemplateResponse(f"latest/{skin_dir}.html", context)
+    temp = templates.TemplateResponse(f"latest/{skin_name}.html", context)
     temp_decode = temp.body.decode("utf-8")
 
     # 캐시 파일 생성


### PR DESCRIPTION
### 작업내용
- 메인페이지 최신글(`render_latest_posts`)영역을 PC/Mobile 구분하여 렌더링
   - 최신글 캐시파일도 PC/Mobile 구분되어 생성

### 적용방법
- 모바일 경로에 파일 추가
    - `templates/{template_name}/mobile/latest/{skin}.html`
- 파일을 갱신할때는 `data/cache`에 있는 데이터 삭제 후 재 실행