### PR TITLE
fix: #284 본인의 게시글 읽을 시 포인트 소진하는 오류 수정

### DIFF
--- a/bbs/board.py
+++ b/bbs/board.py
@@ -831,7 +831,7 @@ async def read_post(
     # 세션 체크
     # 한번 읽은 게시글은 세션만료까지 조회수, 포인트 처리를 하지 않는다.
     session_name = f"ss_view_{bo_table}_{wr_id}"
-    if not request.session.get(session_name):
+    if not request.session.get(session_name) and member.mb_id != write.mb_id:
         # 포인트 검사
         if config.cf_use_point:
             read_point = board.bo_read_point


### PR DESCRIPTION
세션과 함께 로그인한 유저 mb_id와 게시글의 mb_id가 일치하지 않을 때의 조건도 비교