### PR TITLE
core.middleware: 개발환경에서는 https 강제 리다이렉팅을 제거한다.

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -71,7 +71,9 @@ def regist_core_middleware(app: FastAPI) -> None:
                    max_age=60 * 60 * 3)
 
     # 모든 들어오는 요청을 HTTPS로 리디렉션하는 미들웨어를 추가합니다.
-    app.add_middleware(HTTPSRedirectMiddleware)
+    # 단 개발환경에서는 제거한다.
+    if not app.debug:
+        app.add_middleware(HTTPSRedirectMiddleware)
 
 
 async def should_run_middleware(request: Request) -> bool:


### PR DESCRIPTION
안녕하세요. 그누보드6 파이썬 버전 소식에 기쁜마음으로 제 개인환경에서 설치해서 사용해보려고 하는 중입니다.
macOS 환경에서 개발하다보니 아마 기준이 되시는 윈도우 환경(?)하고 조금 차이가 발생하는 것 같습니다.

최초 진입시 설치페이지로 리다이렉팅을 하는데 HTTPS 미들웨어로 강제 리다이렉팅이 되는 듯하여 디버그 모드에서는
우선은 제거하도록 수정해보았습니다. 더 나은 방향이 있거나 다른 의도가 있다면 그쪽으로 안내해주셔도 좋을 것 같습니다.

감사합니다.
건승하세요.


## 수정전
<img width="1039" alt="스크린샷 2024-01-16 오후 10 34 56" src="https://github.com/gnuboard/g6/assets/5110323/4b33fbb6-1456-48a5-821f-4fd4a2df43fa">
<img width="745" alt="스크린샷 2024-01-16 오후 10 35 08" src="https://github.com/gnuboard/g6/assets/5110323/9201275e-d180-443f-9462-debfce676e8c">


## 수정후
<img width="2344" alt="스크린샷 2024-01-16 오후 10 36 28" src="https://github.com/gnuboard/g6/assets/5110323/2ef2c120-3232-4e3e-ad4d-47b137794f9c">


sqlite3에서 초기설치도 macOS 환경에서는 조금 이슈가 있는 것 같지만 이것도 차차 공유해보겠습니다.


