### PR TITLE
fix: 반응형 > 모바일 메인페이지 깨짐 문제 수정 외 4건

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -47,14 +47,15 @@ def regist_core_middleware(app: FastAPI) -> None:
         # 반응형이라면 PC/모바일 버전 설정 세션을 초기화합니다.
         if request.state.is_responsive:
             request.session["is_mobile"] = False
-
-        if request.session.get("is_mobile"):
-            request.state.is_mobile = request.session.get("is_mobile", False)
         else:
-            # User-Agent 헤더를 통해 모바일 여부를 판단합니다. (모바일과 태블릿 접속)
-            user_agent = parse(request.headers.get("User-Agent", ""))
-            if user_agent.is_mobile or user_agent.is_tablet:
-                request.state.is_mobile = True
+            # 사용자가 설정한 PC/모바일 버전 설정 세션을 확인합니다.
+            if request.session.get("is_mobile"):
+                request.state.is_mobile = request.session.get("is_mobile", False)
+            else:
+                # User-Agent 헤더를 통해 모바일 여부를 판단합니다. (모바일과 태블릿 접속)
+                user_agent = parse(request.headers.get("User-Agent", ""))
+                if user_agent.is_mobile or user_agent.is_tablet:
+                    request.state.is_mobile = True
 
         # 디바이스 기본값 설정
         request.state.device = "mobile" if request.state.is_mobile else "pc"

--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -183,7 +183,11 @@ class BoardConfig():
         Returns:
             list: 게시판 카테고리 목록.
         """
-        return self.board.bo_category_list.split("|") if self.board.bo_use_category else []
+        if (not self.board.bo_use_category 
+                or self.board.bo_category_list == ""):
+            return []
+
+        return self.board.bo_category_list.split("|")
 
     def get_display_ip(self, ip: str) -> str:
         """IP 주소를 표시형식으로 변환

--- a/lib/common.py
+++ b/lib/common.py
@@ -411,7 +411,7 @@ def nl2br(value) -> str:
 
 popular_cache = TTLCache(maxsize=10, ttl=300)
 
-def get_populars(limit: int = 7, day: int = 3):
+def get_populars(limit: int = 10, day: int = 3):
     """인기검색어 조회
 
     Args:

--- a/templates/basic/bbs/popular.html
+++ b/templates/basic/bbs/popular.html
@@ -16,6 +16,8 @@
         </div>
     </section>
 
+    <link rel="stylesheet" href="{{ url_for('static', path='/js/owlcarousel/owl.carousel.min.css') }}">
+    <script src="{{ url_for('static', path='/js/owlcarousel/owl.carousel.min.js') }}"></script>
     <script>
         jQuery(function($){
             

--- a/templates/basic/board/basic/list_post.html
+++ b/templates/basic/board/basic/list_post.html
@@ -161,8 +161,9 @@
                     <td class="td_datetime">{{ write.datetime }}</td>
                 </tr>
                 {% endfor %}
+
                 {% for write in writes %}
-                {% set reply_depth=write.wr_reply|length %}
+                    {% set reply_depth=write.wr_reply|length %}
                     <tr class="{{ loop.cycle("", "even") }}">
                         {% if is_admin %}
                         <td class="td_chk chk_box">
@@ -225,6 +226,8 @@
                         {% endif %}
                         <td class="td_datetime">{{ write.wr_datetime|datetime_format('%y-%m-%d') }}</td>
                     </tr>
+                {% else %}
+                    <tr><td colspan="9" class="empty_table">게시글이 없습니다.</td></tr>
                 {% endfor %}
                 </tbody>
             </table>

--- a/templates/basic/board/gallery/list_post.html
+++ b/templates/basic/board/gallery/list_post.html
@@ -171,6 +171,8 @@
                     </div>
                 </div>
             </li>
+            {% else %}
+            <li class="empty_list">게시글이 없습니다.</li>
             {% endfor %}
         </ul>
         <!-- 페이지 -->

--- a/templates/basic/faq/faq.html
+++ b/templates/basic/faq/faq.html
@@ -4,142 +4,137 @@
     <link rel="stylesheet" href="{{ theme_asset(request, 'css/faq.css') }}">
 {% endblock head %}
 
+{% block title %}{{ faq_master.fm_subject }}{% endblock title %}
+{% block subtitle %}{{ faq_master.fm_subject }}{% endblock subtitle %}
+
 {% block content %}
     {% set stx = request.query_params.get("stx", "") %}
 
-    <div id="container">
-        <h2 id="container_title">
-            <span title="{{ faq_master.fm_subject }}">
-            {{ faq_master.fm_subject }}
-            </span>
-        </h2>
-        <!-- FAQ 시작 { -->
-        {% if fm_himg_url %}
-            <div id="faq_himg" class="faq_img">
-                <img src="{{ fm_himg_url }}" alt="">
-            </div>
-        {% endif %}
-        <div id="faq_hhtml">{{ faq_master.fm_head_html|default('', true)|safe }}</div>
-
-        <fieldset id="faq_sch">
-            <legend>FAQ 검색</legend>
-            <form name="faq_search_form" method="get">
-                <span class="sch_tit">FAQ 검색</span>
-                <label for="stx" class="sound_only">검색어<strong class="sound_only"> 필수</strong></label>
-                <input type="text" name="stx" value="{{ stx }}" required="" id="stx" class="frm_input" size="15" maxlength="15">
-                <button type="submit" value="검색" class="btn_submit">
-                    <i class="fa fa-search" aria-hidden="true"></i>
-                    검색
-                </button>
-            </form>
-        </fieldset>
-
-        <nav id="bo_cate">
-            <h2>자주하시는 질문 분류</h2>
-            <ul id="bo_cate_ul">
-                {% for master in faq_masters %} 
-                    <li>
-                        <a href="{{ url_for('faq_view', fm_id=master.fm_id) }}" {% if master.fm_id == faq_master.fm_id %}id="bo_cate_on"{% endif %}>
-                            {% if master.fm_id == faq_master.fm_id %}<span class="sound_only">열린 분류 </span>{% endif %}
-                            {{ master.fm_subject }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
-        </nav>
-
-        <div id="faq_wrap" class="faq_{{ faq_master.fm_id }}">
-            {% for faq in faqs %}
-                <section id="faq_con">
-                    <h2>{{ faq_master.subject }} 목록</h2>
-                    <ol>
-                        <li>
-                            <h3>
-                                <span class="tit_bg">Q</span>
-                                <a href="#none" onclick="return faq_open(this);">{{ faq.fa_subject|safe }}</a>
-                                <button class="tit_btn" onclick="return faq_open(this);">
-                                    <i class="fa fa-plus" aria-hidden="true"></i>
-                                    <span class="sound_only">열기</span>
-                                </button>
-                            </h3>
-                            <div class="con_inner" style="display: none;">
-                                {{ faq.fa_content|safe }}
-                                <button type="button" class="closer_btn">
-                                    <i class="fa fa-minus" aria-hidden="true"></i>
-                                    <span class="sound_only">닫기</span>
-                                </button>
-                            </div>
-                        </li>
-                    </ol>
-                </section>
-            {% else %}
-                <div class="empty_list">
-                    등록된 FAQ가 없습니다.
-                    {# 관리자만 표시하도록 수정 #}
-                    <br>
-                    <a href="{{ url_for('faq_master_list') }}">FAQ를 새로 등록하시려면 FAQ관리</a> 메뉴를 이용하십시오.
-                </div>
-            {% endfor %}
+    <!-- FAQ 시작 { -->
+    {% if fm_himg_url %}
+        <div id="faq_himg" class="faq_img">
+            <img src="{{ fm_himg_url }}" alt="">
         </div>
+    {% endif %}
+    <div id="faq_hhtml">{{ faq_master.fm_head_html|default('', true)|safe }}</div>
 
-        <div id="faq_thtml">{{ faq_master.fm_tail_html|default('', true)|safe }}</div>
-        {% if fm_timg_url %}
-            <div id="faq_timg" class="faq_img">
-                <img src="{{ fm_timg_url }}" alt="">
-            </div>
-        {% endif %}
+    <fieldset id="faq_sch">
+        <legend>FAQ 검색</legend>
+        <form name="faq_search_form" method="get">
+            <span class="sch_tit">FAQ 검색</span>
+            <label for="stx" class="sound_only">검색어<strong class="sound_only"> 필수</strong></label>
+            <input type="text" name="stx" value="{{ stx }}" required="" id="stx" class="frm_input" size="15" maxlength="15">
+            <button type="submit" value="검색" class="btn_submit">
+                <i class="fa fa-search" aria-hidden="true"></i>
+                검색
+            </button>
+        </form>
+    </fieldset>
 
-        {% if request.state.is_super_admin %}
+    <nav id="bo_cate">
+        <h2>자주하시는 질문 분류</h2>
+        <ul id="bo_cate_ul">
+        {% for master in faq_masters %} 
+            <li>
+                <a href="{{ url_for('faq_view', fm_id=master.fm_id) }}" {% if master.fm_id == faq_master.fm_id %}id="bo_cate_on"{% endif %}>
+                    {% if master.fm_id == faq_master.fm_id %}<span class="sound_only">열린 분류 </span>{% endif %}
+                    {{ master.fm_subject }}
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+    </nav>
+
+    <div id="faq_wrap" class="faq_{{ faq_master.fm_id }}">
+    {% for faq in faqs %}
+        <section id="faq_con">
+            <h2>{{ faq_master.subject }} 목록</h2>
+            <ol>
+                <li>
+                    <h3>
+                        <span class="tit_bg">Q</span>
+                        <a href="#none" onclick="return faq_open(this);">{{ faq.fa_subject|safe }}</a>
+                        <button class="tit_btn" onclick="return faq_open(this);">
+                            <i class="fa fa-plus" aria-hidden="true"></i>
+                            <span class="sound_only">열기</span>
+                        </button>
+                    </h3>
+                    <div class="con_inner" style="display: none;">
+                        {{ faq.fa_content|safe }}
+                        <button type="button" class="closer_btn">
+                            <i class="fa fa-minus" aria-hidden="true"></i>
+                            <span class="sound_only">닫기</span>
+                        </button>
+                    </div>
+                </li>
+            </ol>
+        </section>
+    {% else %}
+        <div class="empty_list">
+            등록된 FAQ가 없습니다.
+            {% if request.state.is_super_admin %}
+                <br>
+                <a href="{{ url_for('faq_master_list') }}">FAQ를 새로 등록하시려면 FAQ관리</a> 메뉴를 이용하십시오.
+            {% endif %}
+        </div>
+    {% endfor %}
+    </div>
+
+    <div id="faq_thtml">{{ faq_master.fm_tail_html|default('', true)|safe }}</div>
+    {% if fm_timg_url %}
+        <div id="faq_timg" class="faq_img">
+            <img src="{{ fm_timg_url }}" alt="">
+        </div>
+    {% endif %}
+
+    {% if request.state.is_super_admin %}
         <div class="faq_admin">
             <a href="{{ url_for('faq_master_update_form', fm_id=faq_master.fm_id) }}" class="btn_admin btn" title="FAQ 수정">
                 <i class="fa fa-cog fa-spin fa-fw"></i>
                 <span class="sound_only">FAQ 수정</span>
             </a>
         </div>
-        {% endif %}
+    {% endif %}
+    <!-- } FAQ 끝 -->
 
-        <!-- } FAQ 끝 -->
-        {# static 경로 함수 적용 필요 #}
-        <script src="/static/js/viewimageresize.js"></script>
-        <script>
-        jQuery(function() {
-            $(".closer_btn").on("click", function() {
-                $(this).closest(".con_inner").slideToggle('slow', function() {
-                    var $h3 = $(this).closest("li").find("h3");
+    <script src="{{ url_for('static', path='/js/viewimageresize.js') }}"></script>
+    <script>
+    jQuery(function() {
+        $(".closer_btn").on("click", function() {
+            $(this).closest(".con_inner").slideToggle('slow', function() {
+                var $h3 = $(this).closest("li").find("h3");
 
-                    $("#faq_con li h3").removeClass("faq_li_open");
-                    if($(this).is(":visible")) {
-                        $h3.addClass("faq_li_open");
-                    }
-                });
+                $("#faq_con li h3").removeClass("faq_li_open");
+                if ($(this).is(":visible")) {
+                    $h3.addClass("faq_li_open");
+                }
             });
         });
+    });
 
-        function faq_open(el)
-        {	
-            var $con = $(el).closest("li").find(".con_inner"),
-                $h3 = $(el).closest("li").find("h3");
+    function faq_open(el)
+    {	
+        var $con = $(el).closest("li").find(".con_inner"),
+            $h3 = $(el).closest("li").find("h3");
 
-            if($con.is(":visible")) {
-                $con.slideUp();
-                $h3.removeClass("faq_li_open");
-            } else {
-                $("#faq_con .con_inner:visible").css("display", "none");
+        if ($con.is(":visible")) {
+            $con.slideUp();
+            $h3.removeClass("faq_li_open");
+        } else {
+            $("#faq_con .con_inner:visible").css("display", "none");
 
-                $con.slideDown(
-                    function() {
-                        // 이미지 리사이즈
-                        $con.viewimageresize2();
-                        $("#faq_con li h3").removeClass("faq_li_open");
+            $con.slideDown(
+                function() {
+                    // 이미지 리사이즈
+                    $con.viewimageresize2();
+                    $("#faq_con li h3").removeClass("faq_li_open");
 
-                        $h3.addClass("faq_li_open");
-                    }
-                );
-            }
-
-            return false;
+                    $h3.addClass("faq_li_open");
+                }
+            );
         }
-        </script>
-    </div>
 
+        return false;
+    }
+    </script>
 {% endblock content %}

--- a/templates/taeho/bbs/popular.html
+++ b/templates/taeho/bbs/popular.html
@@ -16,6 +16,8 @@
         </div>
     </section>
 
+    <link rel="stylesheet" href="{{ url_for('static', path='/js/owlcarousel/owl.carousel.min.css') }}">
+    <script src="{{ url_for('static', path='/js/owlcarousel/owl.carousel.min.js') }}"></script>
     <script>
         jQuery(function($){
             

--- a/templates/taeho/board/basic/list_post.html
+++ b/templates/taeho/board/basic/list_post.html
@@ -161,8 +161,9 @@
                     <td class="td_datetime">{{ write.datetime }}</td>
                 </tr>
                 {% endfor %}
+
                 {% for write in writes %}
-                {% set reply_depth=write.wr_reply|length %}
+                    {% set reply_depth=write.wr_reply|length %}
                     <tr class="{{ loop.cycle("", "even") }}">
                         {% if is_admin %}
                         <td class="td_chk chk_box">
@@ -225,6 +226,8 @@
                         {% endif %}
                         <td class="td_datetime">{{ write.wr_datetime|datetime_format('%y-%m-%d') }}</td>
                     </tr>
+                {% else %}
+                    <tr><td colspan="9" class="empty_table">게시글이 없습니다.</td></tr>
                 {% endfor %}
                 </tbody>
             </table>

--- a/templates/taeho/board/gallery/list_post.html
+++ b/templates/taeho/board/gallery/list_post.html
@@ -171,6 +171,8 @@
                     </div>
                 </div>
             </li>
+            {% else %}
+            <li class="empty_list">게시글이 없습니다.</li>
             {% endfor %}
         </ul>
         <!-- 페이지 -->

--- a/templates/taeho/faq/faq.html
+++ b/templates/taeho/faq/faq.html
@@ -1,141 +1,140 @@
 {% extends "base.html" %}
+
 {% block head %}
     <link rel="stylesheet" href="{{ theme_asset(request, 'css/faq.css') }}">
-{% endblock head%}
+{% endblock head %}
+
+{% block title %}{{ faq_master.fm_subject }}{% endblock title %}
+{% block subtitle %}{{ faq_master.fm_subject }}{% endblock subtitle %}
+
 {% block content %}
+    {% set stx = request.query_params.get("stx", "") %}
 
-        <h2 id="container_title">
-            <span title="{{ faq_master.fm_subject }}">
-            {{ faq_master.fm_subject }}
-            </span>
-        </h2>
-        <!-- FAQ 시작 { -->
-        {% if fm_himg_url %}
-            <div id="faq_himg" class="faq_img">
-                <img src="{{ fm_himg_url }}" alt="">
-            </div>
-        {% endif %}
-        <div id="faq_hhtml">{{ faq_master.fm_head_html|default('', true)|safe }}</div>
-
-        <fieldset id="faq_sch">
-            <legend>FAQ 검색</legend>
-            <form name="faq_search_form" method="get">
-                <span class="sch_tit">FAQ 검색</span>
-                <label for="stx" class="sound_only">검색어<strong class="sound_only"> 필수</strong></label>
-                <input type="text" name="stx" value="{{ request.state.stx|default('', true) }}" required="" id="stx" class="frm_input" size="15" maxlength="15">
-                <button type="submit" value="검색" class="btn_submit">
-                    <i class="fa fa-search" aria-hidden="true"></i>
-                    검색
-                </button>
-            </form>
-        </fieldset>
-
-        <nav id="bo_cate">
-            <h2>자주하시는 질문 분류</h2>
-            <ul id="bo_cate_ul">
-                {% for master in faq_masters %} 
-                    <li>
-                        <a href="{{ url_for('faq_view', fm_id=master.fm_id) }}" {% if master.fm_id == faq_master.fm_id %}id="bo_cate_on"{% endif %}>
-                            {% if master.fm_id == faq_master.fm_id %}<span class="sound_only">열린 분류 </span>{% endif %}
-                            {{ master.fm_subject }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
-        </nav>
-
-        <div id="faq_wrap" class="faq_{{ faq_master.fm_id }}">
-            {% for faq in faqs %}
-                <section id="faq_con">
-                    <h2>{{ faq_master.subject }} 목록</h2>
-                    <ol>
-                        <li>
-                            <h3>
-                                <span class="tit_bg">Q</span>
-                                <a href="#none" onclick="return faq_open(this);">{{ faq.fa_subject|safe }}</a>
-                                <button class="tit_btn" onclick="return faq_open(this);">
-                                    <i class="fa fa-plus" aria-hidden="true"></i>
-                                    <span class="sound_only">열기</span>
-                                </button>
-                            </h3>
-                            <div class="con_inner" style="display: none;">
-                                {{ faq.fa_content|safe }}
-                                <button type="button" class="closer_btn">
-                                    <i class="fa fa-minus" aria-hidden="true"></i>
-                                    <span class="sound_only">닫기</span>
-                                </button>
-                            </div>
-                        </li>
-                    </ol>
-                </section>
-            {% else %}
-                <div class="empty_list">
-                    등록된 FAQ가 없습니다.
-                    {# 관리자만 표시하도록 수정 #}
-                    <br>
-                    <a href="{{ url_for('faq_master_list') }}">FAQ를 새로 등록하시려면 FAQ관리</a> 메뉴를 이용하십시오.
-                </div>
-            {% endfor %}
+    <!-- FAQ 시작 { -->
+    {% if fm_himg_url %}
+        <div id="faq_himg" class="faq_img">
+            <img src="{{ fm_himg_url }}" alt="">
         </div>
+    {% endif %}
+    <div id="faq_hhtml">{{ faq_master.fm_head_html|default('', true)|safe }}</div>
 
-        <div id="faq_thtml">{{ faq_master.fm_tail_html|default('', true)|safe }}</div>
-        {% if fm_timg_url %}
-            <div id="faq_timg" class="faq_img">
-                <img src="{{ fm_timg_url }}" alt="">
-            </div>
-        {% endif %}
+    <fieldset id="faq_sch">
+        <legend>FAQ 검색</legend>
+        <form name="faq_search_form" method="get">
+            <span class="sch_tit">FAQ 검색</span>
+            <label for="stx" class="sound_only">검색어<strong class="sound_only"> 필수</strong></label>
+            <input type="text" name="stx" value="{{ stx }}" required="" id="stx" class="frm_input" size="15" maxlength="15">
+            <button type="submit" value="검색" class="btn_submit">
+                <i class="fa fa-search" aria-hidden="true"></i>
+                검색
+            </button>
+        </form>
+    </fieldset>
 
-        {% if request.state.is_super_admin %}
+    <nav id="bo_cate">
+        <h2>자주하시는 질문 분류</h2>
+        <ul id="bo_cate_ul">
+        {% for master in faq_masters %} 
+            <li>
+                <a href="{{ url_for('faq_view', fm_id=master.fm_id) }}" {% if master.fm_id == faq_master.fm_id %}id="bo_cate_on"{% endif %}>
+                    {% if master.fm_id == faq_master.fm_id %}<span class="sound_only">열린 분류 </span>{% endif %}
+                    {{ master.fm_subject }}
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+    </nav>
+
+    <div id="faq_wrap" class="faq_{{ faq_master.fm_id }}">
+    {% for faq in faqs %}
+        <section id="faq_con">
+            <h2>{{ faq_master.subject }} 목록</h2>
+            <ol>
+                <li>
+                    <h3>
+                        <span class="tit_bg">Q</span>
+                        <a href="#none" onclick="return faq_open(this);">{{ faq.fa_subject|safe }}</a>
+                        <button class="tit_btn" onclick="return faq_open(this);">
+                            <i class="fa fa-plus" aria-hidden="true"></i>
+                            <span class="sound_only">열기</span>
+                        </button>
+                    </h3>
+                    <div class="con_inner" style="display: none;">
+                        {{ faq.fa_content|safe }}
+                        <button type="button" class="closer_btn">
+                            <i class="fa fa-minus" aria-hidden="true"></i>
+                            <span class="sound_only">닫기</span>
+                        </button>
+                    </div>
+                </li>
+            </ol>
+        </section>
+    {% else %}
+        <div class="empty_list">
+            등록된 FAQ가 없습니다.
+            {% if request.state.is_super_admin %}
+                <br>
+                <a href="{{ url_for('faq_master_list') }}">FAQ를 새로 등록하시려면 FAQ관리</a> 메뉴를 이용하십시오.
+            {% endif %}
+        </div>
+    {% endfor %}
+    </div>
+
+    <div id="faq_thtml">{{ faq_master.fm_tail_html|default('', true)|safe }}</div>
+    {% if fm_timg_url %}
+        <div id="faq_timg" class="faq_img">
+            <img src="{{ fm_timg_url }}" alt="">
+        </div>
+    {% endif %}
+
+    {% if request.state.is_super_admin %}
         <div class="faq_admin">
             <a href="{{ url_for('faq_master_update_form', fm_id=faq_master.fm_id) }}" class="btn_admin btn" title="FAQ 수정">
                 <i class="fa fa-cog fa-spin fa-fw"></i>
                 <span class="sound_only">FAQ 수정</span>
             </a>
         </div>
-        {% endif %}
+    {% endif %}
+    <!-- } FAQ 끝 -->
 
-        <!-- } FAQ 끝 -->
-        {# static 경로 함수 적용 필요 #}
-        <script src="/static/js/viewimageresize.js"></script>
-        <script>
-        jQuery(function() {
-            $(".closer_btn").on("click", function() {
-                $(this).closest(".con_inner").slideToggle('slow', function() {
-                    var $h3 = $(this).closest("li").find("h3");
+    <script src="{{ url_for('static', path='/js/viewimageresize.js') }}"></script>
+    <script>
+    jQuery(function() {
+        $(".closer_btn").on("click", function() {
+            $(this).closest(".con_inner").slideToggle('slow', function() {
+                var $h3 = $(this).closest("li").find("h3");
 
-                    $("#faq_con li h3").removeClass("faq_li_open");
-                    if($(this).is(":visible")) {
-                        $h3.addClass("faq_li_open");
-                    }
-                });
+                $("#faq_con li h3").removeClass("faq_li_open");
+                if ($(this).is(":visible")) {
+                    $h3.addClass("faq_li_open");
+                }
             });
         });
+    });
 
-        function faq_open(el)
-        {	
-            var $con = $(el).closest("li").find(".con_inner"),
-                $h3 = $(el).closest("li").find("h3");
+    function faq_open(el)
+    {	
+        var $con = $(el).closest("li").find(".con_inner"),
+            $h3 = $(el).closest("li").find("h3");
 
-            if($con.is(":visible")) {
-                $con.slideUp();
-                $h3.removeClass("faq_li_open");
-            } else {
-                $("#faq_con .con_inner:visible").css("display", "none");
+        if ($con.is(":visible")) {
+            $con.slideUp();
+            $h3.removeClass("faq_li_open");
+        } else {
+            $("#faq_con .con_inner:visible").css("display", "none");
 
-                $con.slideDown(
-                    function() {
-                        // 이미지 리사이즈
-                        $con.viewimageresize2();
-                        $("#faq_con li h3").removeClass("faq_li_open");
+            $con.slideDown(
+                function() {
+                    // 이미지 리사이즈
+                    $con.viewimageresize2();
+                    $("#faq_con li h3").removeClass("faq_li_open");
 
-                        $h3.addClass("faq_li_open");
-                    }
-                );
-            }
-
-            return false;
+                    $h3.addClass("faq_li_open");
+                }
+            );
         }
-        </script>
 
-
+        return false;
+    }
+    </script>
 {% endblock content %}


### PR DESCRIPTION
### 작업내용
#### 1. 반응형 > 모바일 메인페이지 깨짐 문제 재 수정. 
   - #293
   - #281 수정한 내용에서 조건문 누락 추가
#### 2. 게시글 목록에서 게시글이 없을 경우 안내문구 추가. 
   - #290 
#### 3. 게시판 분류 사용 & 분류가 빈 값일 경우 표시 오류 수정
![240117분류 오류](https://github.com/gnuboard/g6/assets/57935683/3a564999-d960-488e-abf7-09b9b21476b7)
#### 4. FAQ > 제목이 두번 렌더링되는 오류 및 들여쓰기 수정
   - #292 
#### 5. 인기 검색어(최근 검색어) > 버튼 동작오류 수정 (owlcarousel 슬라이드 적용)
   - #300 
   - 인기검색어 출력 갯수 수정 (7개 -> 10개)
