### PR TITLE
chore: starlette 버전이 0.27.0 이상 설치되도록 수정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==2.0.23
 sse-starlette>=0.10.3
-starlette==0.27.0
+starlette>=0.27.0
 tenacity==8.2.3
 testresources>=2.0.1
 typing-extensions>=4.7.1


### PR DESCRIPTION
### 작업내용
- fastapi 0.109.0 버전 설치 오류 해결

```bash
ERROR: fastapi 0.109.0 has requirement starlette<0.36.0,>=0.35.0, but you'll have starlette 0.27.0 which is incompatible.
```