### PR TITLE
fix: starlette 버전이 0.29 이상일 경우, template_response 함수 오류 수정

### DIFF
--- a/core/exception.py
+++ b/core/exception.py
@@ -75,4 +75,8 @@ def template_response(
     #   처음 설치 시에는 DB가 없으므로 새로운 템플릿 응답 객체를 생성합니다.
     template = Jinja2Templates(directory=TEMPLATES_DIR)
     template.env.globals["theme_asset"] = theme_asset
-    return template.TemplateResponse(template_html, context, status_code)
+    return template.TemplateResponse(
+        name=template_html,
+        context=context,
+        status_code=status_code
+    )


### PR DESCRIPTION
### 원인
-  starlette 버전 0.29부터 **TemplateResponse 인자가 변경**되어 오류 발생
- #249 참고

### 작업내용
- `core.py` > `template_response` 함수
   - template.TemplateResponse > 인자 전달방식 변경 **(함수 => 키워드)**

추후 fastapi, starlette 버전 및 전체 템플릿 응답처리 부분에서 수정이 필요함.