### PR TITLE
env/fix: 유닉스 환경변수 규칙 준수

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,15 +197,15 @@ pip install -r requirements.txt
 # (DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME)
 
 # 테이블 이름 접두사 설정
-DB_TABLE_PREFIX = "g6_"
+DB_TABLE_PREFIX="g6_"
 # mysql, postgresql, sqlite
-DB_ENGINE = ""
-DB_USER = "username"
-DB_PASSWORD = ""
-DB_HOST = ""
-DB_PORT = ""
-DB_NAME = ""
-DB_CHARSET = "utf8"
+DB_ENGINE=""
+DB_USER="username"
+DB_PASSWORD=""
+DB_HOST=""
+DB_PORT=""
+DB_NAME=""
+DB_CHARSET="utf8"
 ```
 #### 이메일 발송 설정
 ```bash
@@ -227,38 +227,38 @@ SMTP_PASSWORD=""
 # 관리자 테마 설정
 # 관리자 테마는 /admin/templates/{테마} 에 위치해야 합니다.
 # 테마 이름을 입력하지 않으면 기본 테마(basic)가 적용됩니다.
-ADMIN_THEME = "basic"
+ADMIN_THEME="basic"
 ```
 
 #### 이미지 설정
 ```bash
 # 이미지 크기변환 여부
-UPLOAD_IMAGE_RESIZE = "False"
+UPLOAD_IMAGE_RESIZE="False"
 # MB 이미지 업로드 용량 (기본값 20MB)
-UPLOAD_IMAGE_SIZE_LIMIT = 20
+UPLOAD_IMAGE_SIZE_LIMIT=20
 # (0~100) default 80 이미지 업로드 퀄리티(jpg)
-UPLOAD_IMAGE_QUALITY = 80
+UPLOAD_IMAGE_QUALITY=80
 
 # UPLOAD_IMAGE_RESIZE 가 True 이고 설정된값보다 크면 크기를 변환합니다.
 # px 이미지 업로드 크기변환 가로 크기
-UPLOAD_IMAGE_RESIZE_WIDTH = 1200
+UPLOAD_IMAGE_RESIZE_WIDTH=1200
 # px 이미지 업로드 크기변환 세로 크기
-UPLOAD_IMAGE_RESIZE_HEIGHT = 2800
+UPLOAD_IMAGE_RESIZE_HEIGHT=2800
 ```
 
 #### 기타 설정들
 ```bash
 # 디버그 모드 설정 (True/False)
-APP_IS_DEBUG = "False"
+APP_IS_DEBUG="False"
 
 # 웹사이트 표시 방법 (True/False)
 # "True" (기본값) : 반응형 웹사이트 (참고: 반응형 템플릿만 제공합니다.)
 # "False" : 적응형 웹사이트
-IS_RESPONSIVE = "True"
+IS_RESPONSIVE="True"
 
 # www.gnuboard.com 과 gnuboard.com 도메인은 서로 다른 도메인으로 인식합니다. 
 # 쿠키를 공유하려면 .gnuboard.com 과 같이 입력하세요.
 # 이곳에 입력하지 않으면 www 붙은 도메인과 그렇지 않은 도메인은 쿠키를 공유하지 못하므로 
 # 로그인이 풀릴 수 있습니다.
-COOKIE_DOMAIN = ""
+COOKIE_DOMAIN=""
 ```

--- a/example.env
+++ b/example.env
@@ -6,21 +6,21 @@
 #DB_DRIVER 는 각 DBMS의 파이썬 드라이버이름입니다.
 # e.g.) mysql 사용시 mysql , pymysql
 
-DB_TABLE_PREFIX = "g6_"
-DB_ENGINE = ""
-DB_USER = "username"
-DB_PASSWORD = ""
-DB_HOST = ""
-DB_PORT = ""
-DB_NAME = ""
-DB_CHARSET = "utf8"
+DB_TABLE_PREFIX="g6_"
+DB_ENGINE=""
+DB_USER="username"
+DB_PASSWORD=""
+DB_HOST=""
+DB_PORT=""
+DB_NAME=""
+DB_CHARSET="utf8"
 
 # 디버그 모드 설정 (True/False)
-APP_IS_DEBUG = "False"
+APP_IS_DEBUG="False"
 
 # 세션 설정
-SESSION_COOKIE_NAME = "session"
-SESSION_SECRET_KEY = "secret_key"
+SESSION_COOKIE_NAME="session"
+SESSION_SECRET_KEY="secret_key"
 
 SMTP_SERVER="localhost"
 SMTP_PORT=25
@@ -31,26 +31,26 @@ SMTP_PASSWORD=""
 # 관리자 테마 설정
 # 관리자 테마는 /admin/templates/{테마} 에 위치해야 합니다.
 # 테마 이름을 입력하지 않으면 기본 테마(basic)가 적용됩니다.
-ADMIN_THEME = "basic"
+ADMIN_THEME="basic"
 
 # 웹사이트 표시 방법 (반드시 문자열로 입력해야 합니다)
 # "True" (기본값) : 반응형 웹사이트 (참고: 반응형 템플릿만 제공합니다.)
 # "False" : 적응형 웹사이트
-IS_RESPONSIVE = "True"
+IS_RESPONSIVE="True"
 
-UPLOAD_IMAGE_RESIZE = "False"
+UPLOAD_IMAGE_RESIZE="False"
 # MB
-UPLOAD_IMAGE_SIZE_LIMIT = 20
+UPLOAD_IMAGE_SIZE_LIMIT=20
 # px
-UPLOAD_IMAGE_RESIZE_WIDTH = 1200
+UPLOAD_IMAGE_RESIZE_WIDTH=1200
 # px
-UPLOAD_IMAGE_RESIZE_HEIGHT = 2800
+UPLOAD_IMAGE_RESIZE_HEIGHT=2800
 # (0~100) default 80
-UPLOAD_IMAGE_QUALITY = 80
+UPLOAD_IMAGE_QUALITY=80
 
 
 # www.gnuboard.com 과 gnuboard.com 도메인은 서로 다른 도메인으로 인식합니다. 
 # 쿠키를 공유하려면 .gnuboard.com 과 같이 입력하세요.
 # 이곳에 입력하지 않으면 www 붙은 도메인과 그렇지 않은 도메인은 쿠키를 공유하지 못하므로 
 # 로그인이 풀릴 수 있습니다.
-COOKIE_DOMAIN = ""
+COOKIE_DOMAIN=""


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [ ] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [ ] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [] 버그 수정
- [ ] 새로운 기능
- [x] 문서내용 수정
- [x] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [x] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->

유닉스 환경에서 env variable 설정 시 variable명과 value 사이에 space가 없습니다.
실제로 다음과 같이 할 시 오류가 발생합니다.

```
bash -c 'source example.env'
#OR
zsh -c 'source example.env'
```

그결과 `os.getenv`로 값을 가져오지 못하고 fallback을 사용하게 됩니다.

docker-compose 에는 그 공백이 어떠한 문제를 야기하지 않을수도 있지만
RHEL 계열, podman-compose 등에서는 mysql 등 환경변수 설정에서부터 문제가 발생할 수 있습니다.


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->

[python-dotenv](https://github.com/theskumar/python-dotenv#getting-started) repo의 기본 syntax 확인 후 리오픈.