### PR TITLE
fix: #263 포인트 소진 경고창에서 비회원 경고문구 추가

### DIFF
--- a/bbs/board.py
+++ b/bbs/board.py
@@ -630,7 +630,12 @@ async def write_update(
         if config.cf_use_point:
             write_point = board.bo_write_point
             if not board_config.is_write_point():
-                raise AlertException(f"글 작성에 필요한 포인트({number_format(abs(write_point))})가 부족합니다.", 403)                
+                point = number_format(abs(write_point))
+                message = f"글 작성에 필요한 포인트({point})가 부족합니다."
+                if not member:
+                    message += f"\\n로그인 후 다시 시도해주세요."
+
+                raise AlertException(message, 403)
 
         form_data.wr_password = create_hash(form_data.wr_password) if form_data.wr_password else ""
         form_data.wr_name = board_config.set_wr_name(member, form_data.wr_name)
@@ -841,7 +846,12 @@ async def read_post(
         if config.cf_use_point:
             read_point = board.bo_read_point
             if not board_config.is_read_point(write):
-                raise AlertException(f"게시글 읽기에 필요한 포인트({number_format(abs(read_point))})가 부족합니다.", 403)
+                point = number_format(abs(read_point))
+                message = f"게시글 읽기에 필요한 포인트({point})가 부족합니다."
+                if not member:
+                    message += f"\\n로그인 후 다시 시도해주세요."
+
+                raise AlertException(message, 403)
             else:
                 insert_point(request, mb_id, read_point, f"{board.bo_subject} {write.wr_id} 글읽기", board.bo_table, write.wr_id, "읽기")
 
@@ -1055,7 +1065,12 @@ async def download_file(
         if config.cf_use_point:
             download_point = board.bo_download_point
             if not board_config.is_download_point(write):
-                raise AlertException(f"파일 다운로드에 필요한 포인트({number_format(abs(download_point))})가 부족합니다.", 403)
+                point = number_format(abs(download_point))
+                message = f"파일 다운로드에 필요한 포인트({point})가 부족합니다."
+                if not member:
+                    message += f"\\n로그인 후 다시 시도해주세요."
+
+                raise AlertException(message, 403)
             else:
                 insert_point(request, mb_id, download_point, f"{board.bo_subject} {write.wr_id} 파일 다운로드", board.bo_table, write.wr_id, "다운로드")
 
@@ -1116,7 +1131,12 @@ async def write_comment_update(
         comment_point = board.bo_comment_point
         if config.cf_use_point:
             if not board_config.is_comment_point():
-                raise AlertException(f"댓글 작성에 필요한 포인트({number_format(abs(comment_point))})가 부족합니다.", 403)
+                point = number_format(abs(comment_point))
+                message = f"댓글 작성에 필요한 포인트({point})가 부족합니다."
+                if not member:
+                    message += f"\\n로그인 후 다시 시도해주세요."
+
+                raise AlertException(message, 403)
 
         # 댓글 객체 생성
         comment = write_model()


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [x] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
제 개발환경에서는 오류 재현이 어려워, 해당 오류 발생 시 로그인 세션이 풀린다는 힌트(?)를 토대로 
**비회원 접근일 경우 경고문구를 추가**했습니다.

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
- #263

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
