### PR TITLE
[fix]. 최근 게시물 폴더(제작자) 사용 허용

### DIFF
--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -1351,7 +1351,8 @@ def render_latest_posts(request: Request, skin_name: str = 'basic', bo_table: st
 
     device = request.state.device
     file_cache = FileCache()
-    cache_filename = f"latest-{bo_table}-{device}-{skin_name}-{rows}-{subject_len}-{file_cache.get_cache_secret_key()}.html"
+    skin_name_for_cache = skin_name.replace('/', '_').replace('\\', '_')
+    cache_filename = f"latest-{bo_table}-{device}-{skin_name_for_cache}-{rows}-{subject_len}-{file_cache.get_cache_secret_key()}.html"
     cache_file = os.path.join(file_cache.cache_dir, cache_filename)
 
     # 캐시된 파일이 있으면 파일을 읽어서 반환


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
최근 게시물의 경우 latest 폴더 내 html 파일을 출력하게 되었으나, 시간이 지나서, 많은 제작자 사용자가 늘어날 경우
파일이 중첩될 경우를 생각해야 한다고 생각합니다.

따라서, 해당 파일을 폴더화를 허용한다면, 조금 더 나은 환경이 되지 않을 까 생각됩니다.
![image](https://github.com/gnuboard/g6/assets/155944061/e343e1ec-d2a8-4693-bb67-9a0d86cc0982)

기존에 
{{ render_latest_posts(request, 'pic_block', 'gallery', 4, 23)|safe }}

이렇게 사용중입니다.
기존과 동일하게 사용이 가능하며, 폴더 사용 시 폴더로 인식되게끔 설정합니다.
{{ render_latest_posts(request, 'sei/list/pic_block', 'gallery', 4, 23)|safe }}

이렇게 폴더를 적용함으로써, 다른 제작자와의 충돌 위험을 벗어날 수 있습니다.

![image](https://github.com/gnuboard/g6/assets/155944061/62b83186-9589-4bbb-a4dd-033cf2722ee2)

정상적으로 동작함을 확인했습니다.


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
