### PR TITLE
[fix] 관리자 1:1문의설정 내 SMS 설정 안내 링크 수정

### DIFF
--- a/admin/templates/basic/qa_config_form.html
+++ b/admin/templates/basic/qa_config_form.html
@@ -53,7 +53,7 @@
                         <tr>
                             <th scope="row"><label for="qa_use_sms">SMS 알림</label></th>
                             <td>
-                                <span class="frm_info">휴대폰 입력을 사용하실 경우 문의글 등록시 등록자가 답변등록시 SMS 알림 수신을 선택할 수 있도록 합니다.<br>SMS 알림을 사용하기 위해서는 기본환경설정 &gt; <a href="http://127.0.0.1/g5-update/adm/config_form.php#anc_cf_sms">SMS 설정</a>을 하셔야 합니다.</span>
+                                <span class="frm_info">휴대폰 입력을 사용하실 경우 문의글 등록시 등록자가 답변등록시 SMS 알림 수신을 선택할 수 있도록 합니다.<br>SMS 알림을 사용하기 위해서는 기본환경설정 &gt; <a href="/admin/config_form#anc_cf_sms">SMS 설정</a>을 하셔야 합니다.</span>
                                 <select name="qa_use_sms" id="qa_use_sms">
                                     <option value="0" {{ get_selected(qa_config.qa_use_sms, 0) }}>사용안함</option>
                                     <option value="1" {{ get_selected(qa_config.qa_use_sms, 1) }}>사용함</option>


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
**Before**
어드민 페이지 - 게시판관리 - 1:1문의설정 페이지 내 `SMS설정` 링크가 `http://127.0.0.1/g5-update/adm/config_form.php#anc_cf_sms`으로 잘못 설정되어 있음

**After**
`/admin/config_form#anc_cf_sms` 링크로 수정

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
