### PR TITLE
fix. DB 호환성 오류 수정

### DIFF
--- a/admin/admin_visit.py
+++ b/admin/admin_visit.py
@@ -195,8 +195,12 @@ async def visit_list(
     # 전체 레코드 개수 계산
     total_records = db.scalar(query.add_columns(func.count(Visit.vi_id)).order_by(None))
     # 최종 쿼리 결과를 가져옵니다.
+    if db.bind.dialect.name == 'sqlite':
+        concat_expr = func.strftime('%Y-%m-%d %H:%M:%S', f'{Visit.vi_date} {Visit.vi_time}')
+    else:
+        concat_expr = func.concat(f'{Visit.vi_date} {Visit.vi_time}')
     visits = db.scalars(
-        query.add_columns(Visit, func.concat(Visit.vi_date, " ", Visit.vi_time).label("vi_datetime"))
+        query.add_columns(Visit, concat_expr.label("vi_datetime"))
         .offset(offset)
         .limit(records_per_page)
     ).all()


### PR DESCRIPTION
sql 문법 차이로 인해 database engine에 따라 쿼리문 분기

<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
visit 테이블 vi_date, vi_time를 조합하여 날짜비교를 하는 연산에서
SQLite: concat 문법이 사용불가하고,
PostgreSQL: 날짜 형식이 유지되어야 비교연산이 가능.
위와 같은 이유로 database 종류에 따라 orm sql문 분기하였습니다.


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
#362 

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
