### PR TITLE
fix: 플러그인 라우터 규칙 접두사 / 를 붙이게 변경

### DIFF
--- a/admin/admin_menu_bbs.json
+++ b/admin/admin_menu_bbs.json
@@ -3,60 +3,60 @@
         {
             "id": "100000",
             "name": "환경설정",
-            "url": "config_form"
+            "url": "/config_form"
         },
         {
             "id": "100100",
             "name": "기본환경설정",
-            "url": "config_form",
+            "url": "/config_form",
             "tag": "admin_config"
         },
         {
             "id": "100200",
             "name": "관리권한설정",
-            "url": "auth_list",
+            "url": "/auth_list",
             "tag": "admin_auth"
         },
         {
             "id": "100280",
             "name": "테마설정",
-            "url": "theme",
+            "url": "/theme",
             "tag": "admin_theme"
         },
         {
             "id": "100290",
             "name": "메뉴설정",
-            "url": "menu_list",
+            "url": "/menu_list",
             "tag": "admin_menu"
         },
         {
             "id": "100300",
             "name": "메일 테스트",
-            "url": "sendmail_test",
+            "url": "/sendmail_test",
             "tag": "admin_sendmail"
         },
         {
             "id": "100310",
             "name": "팝업레이어관리",
-            "url": "newwin_list",
+            "url": "/newwin_list",
             "tag": "admin_newwin"
         },
         {
             "id": "100900",
             "name": "캐시파일 일괄삭제",
-            "url": "cache_file_delete",
+            "url": "/cache_file_delete",
             "tag": "admin_cache"
         },
         {
             "id": "100400",
             "name": "부가서비스",
-            "url": "service",
+            "url": "/service",
             "tag": ""
         },
         {
             "id": "100420",
             "name": "플러그인 관리",
-            "url": "plugin_list",
+            "url": "/plugin_list",
             "tag": "admin_plugin"
         }
     ],
@@ -64,48 +64,48 @@
         {
             "id": "200000",
             "name": "회원관리",
-            "url": "member_list"
+            "url": "/member_list"
         },
         {
             "id": "200100",
             "name": "회원관리",
-            "url": "member_list",
+            "url": "/member_list",
             "tag": "admin_member"
         },
         {
             "id": "200300",
             "name": "회원메일발송",
-            "url": "mail_list",
+            "url": "/mail_list",
             "tag": "admin_mail"
         },
         {
             "id": "200800",
             "name": "접속자집계",
-            "url": "visit_list",
+            "url": "/visit_list",
             "tag": "admin_visit_list"
         },
         {
             "id": "200810",
             "name": "접속자검색",
-            "url": "visit_search",
+            "url": "/visit_search",
             "tag": "admin_visit_search"
         },
         {
             "id": "200820",
             "name": "접속자로그삭제",
-            "url": "visit_delete",
+            "url": "/visit_delete",
             "tag": "admin_visit_delete"
         },
         {
             "id": "200200",
             "name": "포인트관리",
-            "url": "point_list",
+            "url": "/point_list",
             "tag": "admin_point"
         },
         {
             "id": "200900",
             "name": "투표관리",
-            "url": "poll_list",
+            "url": "/poll_list",
             "tag": "admin_poll"
         }
     ],
@@ -113,54 +113,54 @@
         {
             "id": "300000",
             "name": "게시판관리",
-            "url": "board_list"
+            "url": "/board_list"
         },
         {
             "id": "300100",
             "name": "게시판관리",
-            "url": "board_list",
+            "url": "/board_list",
             "tag": "admin_board"
         },
         {
             "id": "300200",
             "name": "게시판그룹관리",
-            "url": "boardgroup_list",
+            "url": "/boardgroup_list",
             "tag": "admin_boardgroup"
         },
         {
             "id": "300300",
             "name": "인기검색어관리",
-            "url": "popular_list",
+            "url": "/popular_list",
             "tag": "admin_popular_list"
         },
         {
             "id": "300400",
             "name": "인기검색어순위",
-            "url": "popular_rank",
+            "url": "/popular_rank",
             "tag": "admin_popular_rank"
         },
         {
             "id": "300500",
             "name": "1:1문의설정",
-            "url": "qa_config",
+            "url": "/qa_config",
             "tag": "admin_qa"
         },
         {
             "id": "300600",
             "name": "내용관리",
-            "url": "content_list",
+            "url": "/content_list",
             "tag": "admin_content"
         },
         {
             "id": "300700",
             "name": "FAQ관리",
-            "url": "faq_master_list",
+            "url": "/faq_master_list",
             "tag": "admin_faq"
         },
         {
             "id": "300820",
             "name": "글,댓글 현황",
-            "url": "write_count",
+            "url": "/write_count",
             "tag": "admin_write_count"
         }
     ]

--- a/admin/admin_menu_shop_incomplete.json
+++ b/admin/admin_menu_shop_incomplete.json
@@ -3,97 +3,97 @@
         {
             "id": "400000",
             "name": "쇼핑몰관리",
-            "url": "shop_admin/",
+            "url": "/shop_admin/",
             "permission": "shop_config"
         },
         {
             "id": "400010",
             "name": "쇼핑몰현황",
-            "url": "shop_admin/",
+            "url": "/shop_admin/",
             "permission": "shop_index"
         },
         {
             "id": "400100",
             "name": "쇼핑몰설정",
-            "url": "shop_admin/configform",
+            "url": "/shop_admin/configform",
             "permission": "scf_config"
         },
         {
             "id": "400400",
             "name": "주문내역",
-            "url": "shop_admin/orderlist",
+            "url": "/shop_admin/orderlist",
             "permission": "scf_order"
         },
         {
             "id": "400440",
             "name": "개인결제관리",
-            "url": "shop_admin/personalpaylist",
+            "url": "/shop_admin/personalpaylist",
             "permission": "scf_personalpay"
         },
         {
             "id": "400200",
             "name": "분류관리",
-            "url": "shop_admin/categorylist",
+            "url": "/shop_admin/categorylist",
             "permission": "scf_cate"
         },
         {
             "id": "400300",
             "name": "상품관리",
-            "url": "shop_admin/itemlist",
+            "url": "/shop_admin/itemlist",
             "permission": "scf_item"
         },
         {
             "id": "400660",
             "name": "상품문의",
-            "url": "shop_admin/itemqalist",
+            "url": "/shop_admin/itemqalist",
             "permission": "scf_item_qna"
         },
         {
             "id": "400650",
             "name": "사용후기",
-            "url": "shop_admin/itemuselist",
+            "url": "/shop_admin/itemuselist",
             "permission": "scf_ps"
         },
         {
             "id": "400620",
             "name": "상품재고관리",
-            "url": "shop_admin/itemstocklist",
+            "url": "/shop_admin/itemstocklist",
             "permission": "scf_item_stock"
         },
         {
             "id": "400610",
             "name": "상품유형관리",
-            "url": "shop_admin/itemtypelist",
+            "url": "/shop_admin/itemtypelist",
             "permission": "scf_item_type"
         },
         {
             "id": "400500",
             "name": "상품옵션재고관리",
-            "url": "shop_admin/optionstocklist",
+            "url": "/shop_admin/optionstocklist",
             "permission": "scf_item_option"
         },
         {
             "id": "400800",
             "name": "쿠폰관리",
-            "url": "shop_admin/couponlist",
+            "url": "/shop_admin/couponlist",
             "permission": "scf_coupon"
         },
         {
             "id": "400810",
             "name": "쿠폰존관리",
-            "url": "shop_admin/couponzonelist",
+            "url": "/shop_admin/couponzonelist",
             "permission": "scf_coupon_zone"
         },
         {
             "id": "400750",
             "name": "추가배송비관리",
-            "url": "shop_admin/sendcostlist",
+            "url": "/shop_admin/sendcostlist",
             "permission": "scf_sendcost"
         },
         {
             "id": "400410",
             "name": "미완료주문",
-            "url": "shop_admin/inorderlist",
+            "url": "/shop_admin/inorderlist",
             "permission": "scf_inorder"
         }
     ],
@@ -101,61 +101,61 @@
         {
             "id": "500000",
             "name": "쇼핑몰현황/기타",
-            "url": "shop_admin/itemsellrank",
+            "url": "/shop_admin/itemsellrank",
             "permission": "shop_stats"
         },
         {
             "id": "500110",
             "name": "매출현황",
-            "url": "shop_admin/sale1",
+            "url": "/shop_admin/sale1",
             "permission": "sst_order_stats"
         },
         {
             "id": "500100",
             "name": "상품판매순위",
-            "url": "shop_admin/itemsellrank",
+            "url": "/shop_admin/itemsellrank",
             "permission": "sst_rank"
         },
         {
             "id": "500120",
             "name": "주문내역출력",
-            "url": "shop_admin/orderprint",
+            "url": "/shop_admin/orderprint",
             "permission": "sst_print_order"
         },
         {
             "id": "500400",
             "name": "재입고SMS알림",
-            "url": "shop_admin/itemstocksms",
+            "url": "/shop_admin/itemstocksms",
             "permission": "sst_stock_sms"
         },
         {
             "id": "500300",
             "name": "이벤트관리",
-            "url": "shop_admin/itemevent",
+            "url": "/shop_admin/itemevent",
             "permission": "scf_event"
         },
         {
             "id": "500310",
             "name": "이벤트일괄처리",
-            "url": "shop_admin/itemeventlist",
+            "url": "/shop_admin/itemeventlist",
             "permission": "scf_event_mng"
         },
         {
             "id": "500500",
             "name": "배너관리",
-            "url": "shop_admin/bannerlist",
+            "url": "/shop_admin/bannerlist",
             "permission": "scf_banner"
         },
         {
             "id": "500140",
             "name": "보관함현황",
-            "url": "shop_admin/wishlist",
+            "url": "/shop_admin/wishlist",
             "permission": "sst_wish"
         },
         {
             "id": "500210",
             "name": "가격비교사이트",
-            "url": "shop_admin/price",
+            "url": "/shop_admin/price",
             "permission": "sst_compare"
         }
     ]

--- a/admin/admin_menu_sms_incomplete.json
+++ b/admin/admin_menu_sms_incomplete.json
@@ -3,67 +3,67 @@
         {
             "id": "900000",
             "name": "SMS 관리",
-            "url": "sms_admin/config",
+            "url": "/sms_admin/config",
             "permission": "sms5"
         },
         {
             "id": "900100",
             "name": "SMS 기본설정",
-            "url": "sms_admin/config",
+            "url": "/sms_admin/config",
             "permission": "sms5_config"
         },
         {
             "id": "900200",
             "name": "회원정보업데이트",
-            "url": "sms_admin/member_update",
+            "url": "/sms_admin/member_update",
             "permission": "sms5_mb_update"
         },
         {
             "id": "900300",
             "name": "문자 보내기",
-            "url": "sms_admin/sms_write",
+            "url": "/sms_admin/sms_write",
             "permission": "sms_write"
         },
         {
             "id": "900400",
             "name": "전송내역-건별",
-            "url": "sms_admin/history_list",
+            "url": "/sms_admin/history_list",
             "permission": "sms_history"
         },
         {
             "id": "900410",
             "name": "전송내역-번호별",
-            "url": "sms_admin/history_num",
+            "url": "/sms_admin/history_num",
             "permission": "sms_history_num"
         },
         {
             "id": "900500",
             "name": "이모티콘 그룹",
-            "url": "sms_admin/form_group",
+            "url": "/sms_admin/form_group",
             "permission": "emoticon_group"
         },
         {
             "id": "900600",
             "name": "이모티콘 관리",
-            "url": "sms_admin/form_list",
+            "url": "/sms_admin/form_list",
             "permission": "emoticon_list"
         },
         {
             "id": "900700",
             "name": "휴대폰번호 그룹",
-            "url": "sms_admin/num_group",
+            "url": "/sms_admin/num_group",
             "permission": "hp_group"
         },
         {
             "id": "900800",
             "name": "휴대폰번호 관리",
-            "url": "sms_admin/num_book",
+            "url": "/sms_admin/num_book",
             "permission": "hp_manage"
         },
         {
             "id": "900900",
             "name": "휴대폰번호 파일",
-            "url": "sms_admin/num_book_file",
+            "url": "/sms_admin/num_book_file",
             "permission": "hp_file"
         }
     ]

--- a/admin/templates/basic/base.html
+++ b/admin/templates/basic/base.html
@@ -111,7 +111,7 @@
                             <ul>
                                 {% for submenu in submenus[1:] %}
                                     <li data-menu="{{ submenu['id'] }}">
-                                        <a href="/admin/{{ submenu['url'] }}" class="gnb_2da">{{ submenu['name'] }}</a>
+                                        <a href="/admin{{ submenu['url'] }}" class="gnb_2da">{{ submenu['name'] }}</a>
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/plugin/demo_plugin/admin/admin_router.py
+++ b/plugin/demo_plugin/admin/admin_router.py
@@ -25,7 +25,7 @@ templates.env.globals["get_admin_plugin_menus"] = get_admin_plugin_menus
 templates.env.globals["get_client_ip"] = get_client_ip
 templates.env.globals["get_all_plugin_module_names"] = get_all_plugin_module_names
 
-admin_router = APIRouter(prefix=f"/{admin_router_prefix}", tags=['demo_admin'])
+admin_router = APIRouter(prefix=admin_router_prefix, tags=['demo_admin'])
 
 
 @admin_router.get("/test_demo_admin")

--- a/plugin/demo_plugin/plugin_config.py
+++ b/plugin/demo_plugin/plugin_config.py
@@ -2,7 +2,8 @@ import os
 
 # module_name 는 플러그인의 폴더 이름입니다.
 module_name = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
-router_prefix = "bbs"
+# 라우터 접두사는 /로 시작해야합니다.
+router_prefix = "/bbs"
 admin_router_prefix = router_prefix
 
 TEMPLATE_PATH = f"{module_name}/templates"
@@ -18,7 +19,7 @@ admin_menu = {
             {
                 "id": module_name + "1",  # 메뉴 아이디
                 "name": "데모 플러그인 메뉴1",
-                "url": f"{admin_router_prefix}/test_demo_admin_template",
+                "url": f"{admin_router_prefix}/test_demo_admin_template", # 라우터 prefix 가 / 로시작하므로 / 붙일 필요가 없습니다.
                 "tag": "demo1",
             },
             {

--- a/plugin/demo_plugin/user/__init__.py
+++ b/plugin/demo_plugin/user/__init__.py
@@ -4,4 +4,4 @@ from ..user.user_router import router
 
 
 def register_user_router():
-    app.include_router(router, prefix=f"/{router_prefix}", tags=[module_name])
+    app.include_router(router, prefix=router_prefix, tags=[module_name])

--- a/plugin/demo_todo/admin/admin_router.py
+++ b/plugin/demo_todo/admin/admin_router.py
@@ -13,7 +13,7 @@ from ..models import Todo
 from ..plugin_config import module_name, admin_router_prefix
 
 templates = AdminTemplates()
-admin_router = APIRouter(prefix=f'/{admin_router_prefix}', tags=['demo_admin'])
+admin_router = APIRouter(prefix=admin_router_prefix, tags=['demo_admin'])
 
 
 @admin_router.get("/test_demo_admin")

--- a/plugin/demo_todo/plugin_config.py
+++ b/plugin/demo_todo/plugin_config.py
@@ -2,7 +2,8 @@ import os
 
 # module_name 는 플러그인의 폴더 이름입니다.
 module_name = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
-router_prefix = "todo"
+# 라우터 접두사는 /로 시작해야합니다.
+router_prefix = "/todo"
 admin_router_prefix = router_prefix
 
 TEMPLATE_PATH = f"{module_name}/templates"
@@ -17,7 +18,7 @@ admin_menu = {
         {
             "id": module_name + "1",  # 메뉴 아이디
             "name": "todo 추가",
-            "url": f"{admin_router_prefix}/create",
+            "url": f"{admin_router_prefix}/create", # 라우터 prefix 가 / 로시작하므로 / 붙일 필요가 없습니다.
             "tag": "demo1"
         },
         {

--- a/plugin/demo_todo/user/__init__.py
+++ b/plugin/demo_todo/user/__init__.py
@@ -4,4 +4,4 @@ from ..plugin_config import module_name, router_prefix
 
 
 def register_user_router():
-    app.include_router(router, prefix=f"/{router_prefix}", tags=[module_name])
+    app.include_router(router, prefix=router_prefix, tags=[module_name])


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
플러그인 작성시 변경사항입니다.
플러그인 url 에 / 프리픽스가 없었느데 접두사가 없는 라우터등록시 오류발생으로 인해
fastapi 라우터처럼  router 접두사에 / 를 붙이게 변경되었습니다.


plugin_config.py 

의 router_prefix, admin_router_prefix 변수 지정시 / 를 반드시 붙여야합니다.

router_prefix  예시
`router_prefix  = '/target_url' `  


플러그인 관리자의 // 중복으로 관리자 메뉴 json 의 url 에 / 추가

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->

https://sir.kr/bbs/board.php?bo_table=g6_plugin&wr_id=1#c_15

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->

