### PR TITLE
[fix]. 회원 이미지 크기 고정

### DIFF
--- a/templates/basic/static/css/default.css
+++ b/templates/basic/static/css/default.css
@@ -1563,7 +1563,7 @@ button { cursor:pointer; padding:0; font-size:inherit; }
 #profile h2 {margin:0 0 5px}
 #profile .profile_name {text-align:center;font-weight:bold}
 #profile .my_profile_img {display:block;margin:20px 0 5px}
-#profile .my_profile_img img {border-radius:50%}
+#profile .my_profile_img img {border-radius:50%;width:50px}
 #profile .profile_img img {border-radius:50%}
 #profile .profile_name .sv_wrap {font-weight:bold;text-align:left}
 
@@ -1883,7 +1883,7 @@ p input:valid + label::after { width:100%; transform:translateX(0); }
 #fregisterform .btn_confirm {text-align:center;max-width: 600px;}
 #fregisterform .form_01 div {margin:0 0 20px}
 #fregisterform .captcha {display:block;margin:5px 0 0}
-#fregisterform .reg_mb_img_file img {max-width:100%;height:auto}
+#fregisterform .reg_mb_img_file img {width:50px;height:auto}
 #reg_mb_icon, #reg_mb_img {float:right}
 
 .tooltip_icon {position: relative;display:inline-block;vertical-align:baseline;color:#b3b5b8;border:0;font-size:1.4em;background:transparent;cursor:pointer;}


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
1. 자기소개 팝업과 정보수정 페이지에서 회원 이미지 크기를 50px로 고정
2. 게시판 등에서 회원 이미지가 50px로 고정되어 있는 것을 참고함

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->

## 기타 정보

![Screenshot 2024-01-25 162207](https://github.com/gnuboard/g6/assets/87285532/3d35b012-3cc3-40ce-be3f-614db2b49c37)

![Screenshot 2024-01-25 162242](https://github.com/gnuboard/g6/assets/87285532/ddfdd489-8a2f-4b6b-81e7-e5b8f1c58d65)