### PR TITLE
fix: 폼 submit 이후 버튼 활성화/비활성화 오류 수정

### DIFF
--- a/lib/captcha/templates/recaptcha_v2.html
+++ b/lib/captcha/templates/recaptcha_v2.html
@@ -8,7 +8,7 @@
     
     {# 사용자가 캡차를 입력했는지 폼전송시 확인 합니다. #}
     function check_captcha(form) {
-        if(document.getElementById(getRecaptchaTokenName()).value == "") {
+        if (document.getElementById(getRecaptchaTokenName()).value == "") {
             alert("자동입력방지를 확인하세요");
             return false;
         }

--- a/lib/captcha/templates/recaptcha_v2_invisible.html
+++ b/lib/captcha/templates/recaptcha_v2_invisible.html
@@ -7,13 +7,10 @@
     
     {# 사용자가 캡차를 입력했는지 폼전송시 확인 합니다. #}
     function check_captcha(form) {
-        form.addEventListener('submit', function(event) {
-            event.preventDefault();
-        });
         if (document.getElementById(getRecaptchaTokenName()).value == "") {
             grecaptcha.execute();
         }
-        
+
         return false;
     }
     

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -761,6 +761,17 @@ $(function() {
 
         return true;
     });
+
+    // 서버에서 에러 반환 시 `btn_submit` 버튼 재활성화
+    // - alert창 이후 history.back()
+    window.onpageshow = function(event){
+        if(event.persisted || (window.performance && performance.getEntriesByType("navigation")[0].type === 'back_forward')) {
+            const $btn_submit = document.getElementById("btn_submit")
+            if ($btn_submit) {
+                $btn_submit.disabled = false;
+            }
+        }
+    }
 });
 
 

--- a/templates/basic/board/basic/read_post.html
+++ b/templates/basic/board/basic/read_post.html
@@ -475,8 +475,8 @@
                     return false;
                 }
             }
-
-            // document.getElementById("btn_submit").disabled = "disabled";
+            
+            document.getElementById("btn_submit").disabled = true;
 
             return true;
         }

--- a/templates/basic/board/basic/write_form.html
+++ b/templates/basic/board/basic/write_form.html
@@ -219,7 +219,7 @@
             f.token.value = generate_token();
             f.action += "?{{ request.query_params|safe }}"
 
-            // document.getElementById("btn_submit").disabled = "disabled";
+            document.getElementById("btn_submit").disabled = true;
 
             return true;
         }

--- a/templates/basic/board/gallery/read_post.html
+++ b/templates/basic/board/gallery/read_post.html
@@ -476,7 +476,7 @@
                 }
             }
 
-            // document.getElementById("btn_submit").disabled = "disabled";
+            document.getElementById("btn_submit").disabled = true;
 
             return true;
         }

--- a/templates/basic/board/gallery/write_form.html
+++ b/templates/basic/board/gallery/write_form.html
@@ -219,7 +219,7 @@
             f.token.value = generate_token();
             f.action += "?{{ request.query_params|safe }}"
 
-            // document.getElementById("btn_submit").disabled = "disabled";
+            document.getElementById("btn_submit").disabled = true;
 
             return true;
         }

--- a/templates/basic/member/register_form.html
+++ b/templates/basic/member/register_form.html
@@ -439,9 +439,9 @@
             // captcha 사용시
             if (typeof check_captcha === "function") {
                 if (!check_captcha(f)) return false;
-                // 캡차함수에서 폼 전송을 하므로 버튼 비활성화
-                document.getElementById("btn_submit").disabled = "disabled";
             }
+
+            document.getElementById("btn_submit").disabled = true;
 
             // 토큰 생성은 폼 체크의 가장 마지막에서 한다.
             f.token.value = generate_token();

--- a/templates/basic/qa/qa_form.html
+++ b/templates/basic/qa/qa_form.html
@@ -125,7 +125,7 @@
                 return false;
             }
             */
-            // document.getElementById("btn_submit").disabled = "disabled";
+            document.getElementById("btn_submit").disabled = true;
 
             f.token.value = generate_token();
 


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [x] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항 
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
### 오류 원인
- 기존에는 `btn_submit` 버튼이 상반되는 두가지 오류를 같이 가지고있었다. 
    1. 활성화 :  서버에서 오류 발생 이후 **재 등록을 못하는** 오류
    2. 비활성화 : form 전송 요청이 **중복 발생**하는 오류
### 처리
- 경고창 출력 이후, `histroy.back()`을 통해서 페이지에 다시 접근하기 때문에  
뒤로가기 이벤트를 체크해서 `btn_submit`버튼을 다시 활성화 하도록 처리함

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
- #350 
- #360 
- #353 

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
- Captcha Temaplate 파일에서 불필요한 스크립트 제거