### PR TITLE
[fix] 섬네일 생성하지 못하는 이미지 예외처리 추가

### DIFF
--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -1096,19 +1096,24 @@ def get_list_thumbnail(request: Request, board: Board, write: WriteBaseModel, th
         # 게시글 본문
         editor_images = get_editor_image(write.wr_content, view=False)
         for image in editor_images:
-            ext = image.split(".")[-1].lower()
-            
-            # 에디터로 삽입된 이미지의 주소는 웹 경로이기에 os.path로 체크할 수 있도록 경로를 변경한다.
-            # 외부 이미지도 썸네일로 보여지기를 희망하는 경우 썸네일 조건 및 생성 로직을 수정해야한다.
-            image = "./data/editor/" + image.split("/data/editor/")[1]
-            
-            # image경로의 파일이 존재하고 이미지파일인지 확인
-            if (os.path.exists(image)
-                    and os.path.isfile(image)
-                    and os.path.getsize(image) > 0
-                    and ext in config.cf_image_extension):
-                source_file = image
-                break
+            try:
+                ext = image.split(".")[-1].lower()
+                
+                # 에디터로 삽입된 이미지의 주소는 웹 경로이기에 os.path로 체크할 수 있도록 경로를 변경한다.
+                # 외부 이미지도 썸네일로 보여지기를 희망하는 경우 썸네일 조건 및 생성 로직을 수정해야한다.
+                image = "./data/editor/" + image.split("/data/editor/")[1]
+                
+                # image경로의 파일이 존재하고 이미지파일인지 확인
+                if (os.path.exists(image)
+                        and os.path.isfile(image)
+                        and os.path.getsize(image) > 0
+                        and ext in config.cf_image_extension):
+                    source_file = image
+                    break
+
+            except Exception as e:
+                print(e)
+                continue
 
     # 섬네일 생성
     if source_file:


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
### `get_list_thumbnail` 함수에서 섬네일을 생성하지 못하는 이미지는 예외처리 하도록 추가
- 이미지 파일에 추가적인 querystring이 붙어있어 생성하지 못하는 것으로 확인됨
- 이후 정확한 파일 확장자를 추출할 수 있도록 코드 개선 필요

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
