### PR TITLE
dev: docker image build

### DIFF
--- a/Base.Dockerfile
+++ b/Base.Dockerfile
@@ -1,0 +1,57 @@
+FROM python:bookworm AS git-base
+
+ARG user=g6
+RUN useradd --create-home --shell /bin/bash $user
+
+WORKDIR /g6
+COPY . .
+
+RUN mkdir -p /g6/data
+RUN chown -R $user:$user /g6
+# Encountering issues with the ownership change of the ./data directory.
+# The exact cause is unclear, however, the COPY --chown option does not 
+# seem to be working as expected for the ./data directory.
+# As a result, we're utilising the RUN command to correctly set the ownership.
+
+RUN find . -mindepth 1 -maxdepth 1 \( -name '.*' ! -name '.' ! -name '..' \) -o \( -name '*.md' -o -name '*.yml' \) -exec bash -c 'echo "Deleting {}"; rm -rf {}' \;
+
+FROM python:bookworm AS env-builder
+
+ARG user=g6
+RUN useradd --create-home --shell /bin/bash $user
+
+ARG TARGETARCH
+COPY --from=git-base /g6/requirements.txt /g6/requirements.txt
+
+WORKDIR /g6
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+        locales \
+        tini
+
+RUN if [ "$TARGETARCH" = "arm" ]; then \
+    apt-get update \
+    && apt-get -y install \
+        cmake \
+        ninja-build \
+        build-essential \
+        g++ \
+        gobjc \
+        meson \
+        liblapack-dev \
+        libblis-dev \
+        libblas-dev \
+        rustc \
+        cargo \
+        libopenblas-dev \
+        python3-dev; \
+    fi
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+RUN dpkg-reconfigure --frontend=noninteractive locales
+RUN python3 -m venv /venv
+RUN /venv/bin/python3 -m pip install -r requirements.txt
+COPY --from=git-base --chown=$user:$user /g6 /standby-g6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:bookworm AS git-base
+WORKDIR /g6
+COPY . .
+RUN find . -mindepth 1 -maxdepth 1 \( -name '.*' ! -name '.' ! -name '..' \) -o \( -name '*.md' -o -name '*.yml' \) -exec bash -c 'echo "Deleting {}"; rm -rf {}' \;
+
+FROM ghcr.io/navystack/gnuboard-g6:base-nightly AS base
+RUN rm -rf /g6/requirements.txt
+COPY --from=git-base --chown=$user:$user /g6/requirements.txt /g6/requirements.txt
+
+RUN /venv/bin/python3 -m pip install -r requirements.txt
+RUN find . -type f \( -name '__pycache__' -o -name '*.pyc' -o -name '*.pyo' \) -exec bash -c 'echo "Deleting {}"; rm -f {}' \;
+
+FROM python:slim-bookworm AS final
+
+ARG user=g6
+RUN useradd --create-home --shell /bin/bash $user
+
+COPY --from=base --chown=$user:$user /standby-g6 /g6
+COPY --from=base --chown=$user:$user /venv /venv
+COPY --from=base --chown=$user:$user /usr/bin/tini /usr/bin/tini
+
+USER g6
+WORKDIR /g6
+VOLUME /g6/data
+EXPOSE 8000
+
+ENTRYPOINT ["tini", "--"]
+# Utilising tini as our init system within the Docker container for graceful start-up and termination.
+# Tini serves as an uncomplicated init system, adept at managing the reaping of zombie processes and forwarding signals.
+# This approach is crucial to circumvent issues with unmanaged subprocesses and signal handling in containerised environments.
+# By integrating tini, we enhance the reliability and stability of our Docker containers.
+# Ensures smooth start-up and shutdown processes, and reliable, safe handling of signal processing.
+
+CMD ["/venv/bin/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Full.Dockerfile
+++ b/Full.Dockerfile
@@ -1,0 +1,80 @@
+FROM python:bookworm AS git-base
+
+ARG user=g6
+RUN useradd --create-home --shell /bin/bash $user
+
+WORKDIR /g6
+COPY . .
+
+RUN mkdir -p /g6/data
+RUN chown -R $user:$user /g6
+# Encountering issues with the ownership change of the ./data directory.
+# The exact cause is unclear, however, the COPY --chown option does not 
+# seem to be working as expected for the ./data directory.
+# As a result, we're utilising the RUN command to correctly set the ownership.
+
+RUN find . -mindepth 1 -maxdepth 1 \( -name '.*' ! -name '.' ! -name '..' \) -o \( -name '*.md' -o -name '*.yml' \) -exec bash -c 'echo "Deleting {}"; rm -rf {}' \;
+
+FROM python:bookworm AS env-builder
+
+ARG user=g6
+RUN useradd --create-home --shell /bin/bash $user
+
+ARG TARGETARCH
+COPY --from=git-base /g6/requirements.txt /g6/requirements.txt
+
+WORKDIR /g6
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+        locales \
+        tini
+
+RUN if [ "$TARGETARCH" = "arm" ]; then \
+    apt-get update \
+    && apt-get -y install \
+        cmake \
+        ninja-build \
+        build-essential \
+        g++ \
+        gobjc \
+        meson \
+        liblapack-dev \
+        libblis-dev \
+        libblas-dev \
+        rustc \
+        cargo \
+        libopenblas-dev \
+        python3-dev; \
+    fi
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+RUN dpkg-reconfigure --frontend=noninteractive locales
+RUN python3 -m venv /venv
+RUN /venv/bin/python3 -m pip install -r requirements.txt -vvv
+RUN find . -type f \( -name '__pycache__' -o -name '*.pyc' -o -name '*.pyo' \) -exec bash -c 'echo "Deleting {}"; rm -f {}' \;
+
+FROM python:slim-bookworm AS final
+
+ARG user=g6
+RUN useradd --create-home --shell /bin/bash $user
+
+COPY --from=git-base --chown=$user:$user /g6 /g6
+COPY --from=env-builder --chown=$user:$user /venv /venv
+COPY --from=env-builder --chown=$user:$user /usr/bin/tini /usr/bin/tini
+
+USER g6
+WORKDIR /g6
+VOLUME /g6/data
+EXPOSE 8000
+
+ENTRYPOINT ["tini", "--"]
+# Utilising tini as our init system within the Docker container for graceful start-up and termination.
+# Tini serves as an uncomplicated init system, adept at managing the reaping of zombie processes and forwarding signals.
+# This approach is crucial to circumvent issues with unmanaged subprocesses and signal handling in containerised environments.
+# By integrating tini, we enhance the reliability and stability of our Docker containers.
+# Ensures smooth start-up and shutdown processes, and reliable, safe handling of signal processing.
+
+CMD ["/venv/bin/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  gnuboard-g6:
+    build:
+      context: .
+      dockerfile: Full.Dockerfile
+    volumes:
+      - gnuboard6-data-dev:/g6/data
+    ports:
+      - "8000:8000"
+
+volumes:
+  gnuboard6-data-dev:


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- 권한 부족으로 #343 PR에 대해 수정하지 못함.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [x] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [x] 기타 (이유를 설명해주세요.)

* Docker 이미지 관련 `docker-compose-dev.yml` 추가로 배포 자동화 가능
*  Unit testing 등 진행 가능.


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
* docker image를 제공 (멀티 아키텍쳐 지원 - AMD 64, ARM64, ARM)
* docker image를 base이미지와 final 이미지로 이분화 (아키텍쳐의 빌드시간을 향상함)
* full build (Full.Dockerfile) 도 가능함.
* 기존 #343 에서 우려되는 부분을 수정함.

---

|구분|기존|변경|기타|
|:--:|:--:|:--:|:--:|
|`USER`|root(UID 0 : GID 0)|g6(UID 1000 : GID 1000)| 잠재적인 권한 오류 및 보안 위험 방지|
|Mount Target|/app|/g6/data||
|dockerfile meta|n/a|expose 8000||
|init|bash|tini| see https://github.com/krallin/tini/issues/8 |


---

docker compose 명령은 아래와 같음
```bash
docker compose -f docker-compose-dev.yml up -d
```

명세된 대로 `Full.Dockerfile`로 빌드를 시도함.


---

기존 #343  에서 docker-compose.yml을 제거함
아직 `semver` 태그가 붙지 않았고, 전반적인 프로젝트 상황을 고려하여 `docker-compose-dev.yml`로 명명

`base` 이미지를 사용하는 방식은 테스트를 위해서 ghcr.io/navystack/gnuboard-g6:base-nightly를 사용함
https://github.com/NavyStack/gnuboard-g6/actions/runs/7609935278 에서 볼수 있듯, 전체를 빌드하면 빌드 시간이 상당함.
업데이트 마다 전체 빌드를 시도하는 것은 비효율적임.

---

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


---


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
