### PR TITLE
fix: 관리자 접속자 시간, 요일 탭 오류 수정

### DIFF
--- a/admin/admin_visit.py
+++ b/admin/admin_visit.py
@@ -477,7 +477,9 @@ async def visit_weekday(
         query = query.add_columns(func.strftime('%w', Visit.vi_date).label('dow'))
     query_result = db.execute(
         query.add_columns(Visit.vi_date, func.count().label('dow_count'))
-        .group_by('dow')
+        .group_by(Visit.vi_date, 'dow')
+        # 데이터베이스 별로 요일(day of week)을 출력하는 기준이 다르기 때문에
+        # vi_date 가 필요하다.
     ).all()
 
     # 요일별 접속자집계

--- a/admin/admin_visit.py
+++ b/admin/admin_visit.py
@@ -428,7 +428,7 @@ async def visit_hour(
     elif dialect == 'sqlite':
         query = query.add_columns(func.strftime('%H', Visit.vi_time).label('hour'))
     query_result = db.execute(
-        query.add_columns(Visit.vi_time, func.count().label('hour_count'))
+        query.add_columns(func.count().label('hour_count'))
         .group_by('hour')
     ).all()
 

--- a/admin/templates/basic/visit_forms.html
+++ b/admin/templates/basic/visit_forms.html
@@ -33,10 +33,10 @@
         {% endif %}
         <div class="sch_last">
             <strong>기간별검색</strong>
-            <input type="text" name="fr_date" value="{{ fr_date }}" id="fr_date" class="frm_input" size="11" maxlength="10">
+            <input type="text" name="fr_date" value="{{ request.query_params.get('fr_date') }}" id="fr_date" class="frm_input" size="11" maxlength="10">
             <label for="fr_date" class="blind">시작일</label>
             ~
-            <input type="text" name="to_date" value="{{ to_date }}" id="to_date" class="frm_input" size="11" maxlength="10">
+            <input type="text" name="to_date" value="{{ request.query_params.get('to_date') }}" id="to_date" class="frm_input" size="11" maxlength="10">
             <label for="to_date" class="blind">종료일</label>
             <input type="submit" value="검색" class="btn_submit">
         </div>

--- a/admin/templates/basic/visit_forms.html
+++ b/admin/templates/basic/visit_forms.html
@@ -33,10 +33,10 @@
         {% endif %}
         <div class="sch_last">
             <strong>기간별검색</strong>
-            <input type="text" name="fr_date" value="{{ request.query_params.get('fr_date') }}" id="fr_date" class="frm_input" size="11" maxlength="10">
+            <input type="text" name="fr_date" value="{{ request.query_params.get('fr_date', '') }}" id="fr_date" class="frm_input" size="11" maxlength="10">
             <label for="fr_date" class="blind">시작일</label>
             ~
-            <input type="text" name="to_date" value="{{ request.query_params.get('to_date') }}" id="to_date" class="frm_input" size="11" maxlength="10">
+            <input type="text" name="to_date" value="{{ request.query_params.get('to_date', '') }}" id="to_date" class="frm_input" size="11" maxlength="10">
             <label for="to_date" class="blind">종료일</label>
             <input type="submit" value="검색" class="btn_submit">
         </div>


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->

1. visit_forms.html이 import 여서 함수를 제외한 상위 템플릿의 context 가 전달되지 않아
날짜 input 태그에 fr_date, to_date 가 표시 되지 않았습니다.  
 -> url 쿼리스트링에서 가져오도록 수정

2. 접속자 , 시간
  Visit.vi_time 을 hour 이름으로 가져와서 Visit.vi_time 은 따로 필요없습니다.
3. 요일 탭 쿼리 group by 시 필요한 컬럼 추가
데이터베이스 별로 요일(day of week)을 출력하는 기준이 다르기 때문에
계산을 위해 vi_date 가 필요
## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
