### PR TITLE
feat. Stored XSS 방지 기능 추가 #314, #387, #390

### DIFF
--- a/bbs/qa.py
+++ b/bbs/qa.py
@@ -1,4 +1,3 @@
-import html as htmllib
 from typing import List
 from typing_extensions import Annotated
 
@@ -18,6 +17,8 @@ from lib.dependencies import (
 )
 from lib.template_filters import number_format, search_font
 from lib.template_functions import get_paging
+from lib.html_sanitizer import subject_sanitizer, content_sanitizer
+
 
 router = APIRouter()
 templates = UserTemplates()
@@ -253,8 +254,9 @@ async def qa_write_update(
         raise AlertException(f"제목/내용에 금지단어({word})가 포함되어 있습니다.", 400)
     
     # Stored XSS 방지
-    form_data.qa_subject = htmllib.escape(form_data.qa_subject)
-    
+    form_data.qa_subject = subject_sanitizer.get_cleaned_data(form_data.qa_subject)
+    form_data.qa_content = content_sanitizer.get_cleaned_data(form_data.qa_content)
+
     # Q&A 업로드파일 크기 검증
     if not request.state.is_super_admin:
         if file1.size > 0 and file1.size > qa_config.qa_upload_size:

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,7 +1,7 @@
 import os
 from user_agents import parse
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -77,6 +77,9 @@ def regist_core_middleware(app: FastAPI) -> None:
     # 클라이언트가 사용할 프로토콜을 결정하는 미들웨어를 추가합니다.
     app.add_middleware(BaseSchemeMiddleware)
 
+    # Content-Security-Policy 헤더를 추가하는 미들웨어를 추가합니다.
+    app.add_middleware(CSPMiddleware)
+
 
 async def should_run_middleware(request: Request) -> bool:
     """미들웨어의 실행 여부를 결정합니다.
@@ -101,6 +104,15 @@ async def should_run_middleware(request: Request) -> bool:
         return False
 
     return True
+
+
+class CSPMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response: Response = await call_next(request)
+        response.headers['Content-Security-Policy'] = (
+            "default-src 'self' 'unsafe-inline';"
+        )
+        return response
 
 
 class BaseSchemeMiddleware(BaseHTTPMiddleware):

--- a/lib/html_sanitizer/__init__.py
+++ b/lib/html_sanitizer/__init__.py
@@ -1,0 +1,4 @@
+from .html_sanitizer import SubjectSanitizer, ContentSanitizer
+
+subject_sanitizer = SubjectSanitizer()
+content_sanitizer = ContentSanitizer()

--- a/lib/html_sanitizer/allowed_dict.py
+++ b/lib/html_sanitizer/allowed_dict.py
@@ -1,0 +1,44 @@
+from typing import Dict, Set
+
+"""
+allowed_attrs_dict에 정리된 태그 속성들은
+허용되는 다른 태그(allowed_tags_dict에 정의된 태그)들에도 공통적으로 적용됩니다.
+key와 value로 구성한 것은 시각적인 목록화를 위한 것입니다.
+해당 태그에만 허용되는 속성이 아닌, 공통 허용 속성입니다.
+
+lxml 라이브러리에서 allow_tags, allow_attrs에 대한 if 문 분기 처리 특성상
+허용하려는 태그나, 속성이 없는 경우에 dict() 또는 set()으로 사용하면 blocklist 방식으로 동작하게 됩니다.
+해당 코드는 allowlist 방식으로 동작하도록 작성되었으므로,
+allow_tags, safe_attrs가 set()과 같이 빈값으로 넘어가지 않아야 합니다.
+그에 따라 모든 태그 또는 모든 속성을 허용하지 않으려는 경우에는 {'None': {''}}와 같은 방식으로 설정합니다.
+"""
+
+
+# BaseSanitizer
+common_allowed_tags_dict: Dict[str, Set[str]] = {'None': {''}}
+common_allowed_attrs_dict: Dict[str, Set[str]] = {'None': {''}}
+
+
+# SubjectSanitizer
+subject_private_allowed_tags_dict: Dict[str, Set[str]] = {'None': {''}}
+subject_private_allowed_attrs_dict: Dict[str, Set[str]] = {'None': {''}}
+
+
+# ContentSanitizer
+content_private_allowed_tags_dict: Dict[str, Set[str]] = {
+    'text': {'span', 'p', 'em', 'i', 'b', 'u', 'small', 'mark', 'del', 'ins', 'sub', 'sup'},
+    'h_tags': {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'},
+    'list': {'ul', 'ol', 'li', 'dl', 'dt', 'dd'},
+    'table': {'table', 'th', 'tr', 'td', 'thead', 'tbody', 'tfoot', 'caption', 'col', 'colgroup'},
+    'block': {'div', 'main', 'section', 'article', 'aside', 'nav'},
+    'formatting': {'blockquote', 'hr', 'br'},
+    'media': {'img', 'audio', 'video', 'source', 'track'},
+    'link': {'a'},
+}
+content_private_allowed_attrs_dict: Dict[str, Set[str]] = {
+    'a': {'href', 'title', 'accesskey', 'class', 'dir', 'id', 'lang', 'name', 'rel', 'tabindex', 'type', 'target'},
+    'table': {'border', 'cellspacing', 'cellpadding', 'align', 'bgcolor', 'summary'},
+    'th': {'scope'},
+    'img': {'src', 'alt', 'title', 'width', 'height', 'align'},
+    'common': {'style'},
+}

--- a/lib/html_sanitizer/html_sanitizer.py
+++ b/lib/html_sanitizer/html_sanitizer.py
@@ -1,0 +1,112 @@
+import abc
+from copy import deepcopy
+from typing import Dict, Set
+from lxml.html import fromstring, tostring
+from lxml.html.clean import Cleaner
+from lxml.html.defs import safe_attrs
+from core.exception import AlertException
+from .allowed_dict import *
+
+
+class XSSCleaner(Cleaner):
+    """
+    lxml.html.clean.Cleaner 클래스를 상속받아
+    필터링 대상이 되는 원본 데이터가 HTML tree가 아닌 경우에도
+    필터링 이후 원본 형식이 유지될 수 있도록 합니다.
+
+    strip_outer_div_tag
+      - 최상단 부모 태그인 <div></div>를 제거합니다
+
+    clean_html
+      - 허용되지 않은 태그 삭제시, 원본 내용이 하나의 HTML Element가 아닌 경우
+        원본 형식을 유지하기 위해 Cleaner.clean_html 메소드를 오버라이딩 한 메소드입니다.
+    """
+
+    def strip_outer_div_tag(self, html_string):
+        html_string = html_string[5:-6]
+        return html_string
+
+    def clean_html(self, html: str):
+        html = f'<div>{html}</div>'
+        html_tree = fromstring(html)
+        self(html_tree)
+        cleaned_html = tostring(html_tree, encoding='unicode', with_tail=False)
+        return self.strip_outer_div_tag(cleaned_html)
+
+
+class BaseSanitizer(metaclass=abc.ABCMeta):
+    """
+    SubjectSanitizer, ContentSanitizer 클래스의 추상 클래스.
+    공통 허용 태그 및 공통 허용 속성을 정의합니다.
+
+    __init___
+      - lxml.html.clean.Cleaner 클래스 및 공통 허용 태그, 공통 허용 속성을 초기화합니다.
+      - is_with_library_attrs를 통해 lxml 라이브러리에서 제공하는
+        html 속성을 허용할지 여부를 결정합니다. 기본값은 False입니다.
+
+    get_combined_filter_dict
+      - 공통 허용 태그 및 속성과 개별 허용 태그 및 속성을 합칩니다.
+
+    get_cleaned_data
+       - 상속받은 클래스에서 오버라이딩하여 사용합니다.
+         최종적으로 허용된 HTML 태그와 속성만을 반환합니다.
+    """
+
+    def __init__(self, is_with_library_attrs=False):
+        self.cleaner = XSSCleaner(safe_attrs_only=True, remove_unknown_tags=False)
+        self.base_allowed_tags_dict = deepcopy(common_allowed_tags_dict)
+        self.base_allowed_attrs_dict = deepcopy(common_allowed_attrs_dict)
+        if is_with_library_attrs:
+            self.base_allowed_attrs_dict['library'] = safe_attrs
+
+    def get_combined_filter_dict(
+        self,
+        base_allowed_dict: Dict[str, Set[str]],
+        private_allowed_dict: Dict[str, Set[str]],
+    ) -> Dict[str, Set[str]]:
+        for key, tags in private_allowed_dict.items():
+            base_allowed_dict[key] = base_allowed_dict.get(key, set()).union(tags)
+        return base_allowed_dict
+
+    @abc.abstractmethod
+    def get_cleaned_data(self, html_content: str):
+        pass
+
+
+class SubjectSanitizer(BaseSanitizer):
+    """
+    게시판 등의 '제목'에 삽입되는 HTML의 XSS 공격 방지를 위한 Sanitizer 클래스
+    """
+
+    def __init__(self, is_with_library_attrs: bool = False):
+        super().__init__(is_with_library_attrs)
+        
+        combined_tags = self.get_combined_filter_dict(self.base_allowed_tags_dict, subject_private_allowed_tags_dict)
+        combined_attrs = self.get_combined_filter_dict(self.base_allowed_attrs_dict, subject_private_allowed_attrs_dict)
+        self.cleaner.allow_tags = {tag for tags in combined_tags.values() for tag in tags}
+        self.cleaner.safe_attrs = {attr for attrs in combined_attrs.values() for attr in attrs}
+    
+    def get_cleaned_data(self, html_content: str) -> str:
+        cleaned_html = self.cleaner.clean_html(html_content)
+
+        if not cleaned_html:
+            raise AlertException("허용되지 않는 HTML 태그들을 변경후 제목을 다시 작성해주세요.", 400)
+
+        return cleaned_html
+
+
+class ContentSanitizer(BaseSanitizer):
+    """
+    게시판 등의 '본문'에 삽입되는 HTML의 XSS 공격 방지를 위한 Sanitizer 클래스
+    """
+
+    def __init__(self, is_with_library_attrs: bool = False):
+        super().__init__(is_with_library_attrs)
+        combined_tags = self.get_combined_filter_dict(self.base_allowed_tags_dict, content_private_allowed_tags_dict)
+        combined_attrs = self.get_combined_filter_dict(self.base_allowed_attrs_dict, content_private_allowed_attrs_dict)
+        self.cleaner.allow_tags = {tag for tags in combined_tags.values() for tag in tags}
+        self.cleaner.safe_attrs = {attr for attrs in combined_attrs.values() for attr in attrs}
+
+    def get_cleaned_data(self, html_content: str) -> str:
+        cleaned_html = self.cleaner.clean_html(html_content)
+        return cleaned_html

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,4 @@ filelock==3.12.2
 APScheduler>=3.10.0
 pymysql==1.1.0
 psycopg2-binary==2.9.9
+lxml==5.1.0

--- a/templates/basic/qa/qa_view.html
+++ b/templates/basic/qa/qa_view.html
@@ -19,7 +19,7 @@
     <!-- 게시물 읽기 시작 { -->
     <article id="bo_v">
         <header>
-            <h2 id="bo_v_title"><span class="bo_v_cate">{{ qa.qa_category }}</span> {{ qa.qa_subject }}</h2>
+            <h2 id="bo_v_title"><span class="bo_v_cate">{{ qa.qa_category }}</span> {{ qa.qa_subject|safe }}</h2>
         </header>
         <section id="bo_v_info">
             <h2>페이지 정보</h2>


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [x] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
### Stored XSS 공격 방지를 위해 2가지 기능 추가
1) HTTP response - Content Security Policy를 활용
 미들웨어의 response header에 src를 통해 불러오는 외부 data에 제한을 둡니다
2) lxml 라이브러리 기반의 html sanitizer 적용
 bleach, nh3, html-sanitizer, DomPurify 등 다양한 라이브러리를 검토
```
 bleach - 가장 범용적이나 2023년 1월부터 deprecated 상태
 nh3 - bleach에 대안으로도 많이 이용되나, 라이브러리의 많은 부분이 Rust로 쓰여있어 디버깅에 어려움이 있을것으로 예상됨
 html-sanitizer - lxml을 dependency로 두고있음, lxml을 직접 사용하며 용도에 맞게 변형하며 사용하는 것이 용이
 DomPurify - 3년 전부터 커밋이 올라오지 않아서 지속적인 관리가 되고 있지 않은 것으로 판단
```
위의 특성들을 고려하여, 범용성, 성능, 라이브러리 유지보수 가능성 측면에서 lxml을 적합할 것으로 판단하고 작업했습니다.

**Allowlist(Whitelist) vs Blocklist(Blacklist)**
lxml 라이브러리는 allowlist, blocklist 두 가지 측면에서 모두 접근이 가능한데,
allow_tags, safe_attrs를 통해서 allowlist 방식으로 XSS에 대응하도록 했습니다.

**style 관련**
개별 html style 속성 허용 O, style 태그 허용 X
- <style></style> 태그 허용시, 게시글 이외의 영역에 모두 영향을 미칠 수 있으므로 허용하지 않는 것을 권장합니다.
- 대신, 개별 태그에 style 속성을 이용하는 것은 홈페이지의 UI를 해치지 않을 것으로 보입니다.


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
#314, https://github.com/gnuboard/g6/pull/387, #390 

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
