### PR TITLE
[fix] #388 게시글 작성시 작성자 정보 누락되는 오류 수정

### DIFF
--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -377,7 +377,7 @@ class BoardConfig():
 
         return ",".join(map(str, notice_ids))
 
-    def set_wr_name(self, member: Member = None, default_name: str = "") -> str:
+    def set_wr_name(self, member: Member = None, default_name: str = None) -> str:
         """실명사용 여부를 확인 후 실명이면 이름을, 아니면 닉네임을 반환한다.
 
         Args:
@@ -392,8 +392,10 @@ class BoardConfig():
                 return member.mb_name
             else:
                 return member.mb_nick
-        else:
+        elif default_name:
             return default_name
+        else:
+            raise AlertException("로그인 세션 만료, 비회원 글쓰기시 작성자 이름 미기재 등의 비정상적인 접근입니다.", 400)
 
     def _can_action_by_level(self, level: int) -> bool:
         """회원 레벨에 따라 행동 가능 여부를 판단한다.


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
로그인 상태에서 작성가능한 게시판에서 로그인 해제후 글 작성시
글쓴이 정보가 누락되는 오류 수정
세션 종료 등, 비정상적인 경로로 작성시 예외처리


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
#388 

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
