### PR TITLE
fix: DBSetting 싱글턴 적용

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -19,7 +19,6 @@ class MySQLCharsetMixin:
 class DBSetting:
     """
     데이터베이스 설정 클래스
-    - 매번 설정이 불러와지는 문제점 해결해야함..
     """
 
     _table_prefix: Annotated[str, ""]
@@ -31,6 +30,8 @@ class DBSetting:
     _name: Annotated[str, ""]
     _url: Annotated[str, ""]
     _charset: Annotated[str, ""]
+    _instance: Annotated['DBSetting', None] = None
+    _setting_init: Annotated[bool, False]
 
     supported_engines = {
         "mysql": "mysql+pymysql",
@@ -38,9 +39,17 @@ class DBSetting:
         "sqlite": "sqlite:///sqlite3.db"
     }
 
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
     def __init__(self) -> None:
-        self.set_connect_infomation()
-        self.create_url()
+        super().__init__()
+        if not hasattr(DBSetting, "_setting_init"):
+            DBSetting._setting_init = True
+            self.set_connect_infomation()
+            self.create_url()
 
     @property
     def charset(self) -> str:

--- a/core/database.py
+++ b/core/database.py
@@ -1,4 +1,4 @@
-from dotenv import dotenv_values, load_dotenv
+from dotenv import dotenv_values
 from fastapi import Depends
 from sqlalchemy import create_engine, URL
 from sqlalchemy.engine import Engine
@@ -72,7 +72,6 @@ class DBSetting:
         self._table_prefix = prefix
 
     def set_connect_infomation(self) -> None:
-        load_dotenv()
         env_values = dotenv_values()
         port = env_values.get("DB_PORT", "3306")
 


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.  설치확인


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->

매번 설정이 불러와지는 문제점 수정 - > DBSetting 클래스도 싱글턴 적용
load_dotenv 삭제 바로 아랫줄  dotenv_values 함수가 env 파일을 호출해서 불필요


단일요청 응답시간은 줄었으나 동시접속자 증가시 문제는 여전합니다.

---
설치확인


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
