### PR TITLE
fix: 사용자페이지에서 게시판, Q&A 여분필드가 입력되지 않는 오류 수정

### DIFF
--- a/core/formclass.py
+++ b/core/formclass.py
@@ -337,6 +337,17 @@ class WriteForm:
     wr_link1: str = Form(None)
     wr_link2: str = Form(None)
 
+    wr_1: str = Form("")
+    wr_2: str = Form("")
+    wr_3: str = Form("")
+    wr_4: str = Form("")
+    wr_5: str = Form("")
+    wr_6: str = Form("")
+    wr_7: str = Form("")
+    wr_8: str = Form("")
+    wr_9: str = Form("")
+    wr_10: str = Form("")
+
 
 @dataclass
 class WriteCommentForm:
@@ -468,6 +479,12 @@ class QaContentForm:
     qa_html: int = Form(None)
     qa_subject: str = Form(...)
     qa_content: str = Form("")
+
+    qa_1: str = Form("")
+    qa_2: str = Form("")
+    qa_3: str = Form("")
+    qa_4: str = Form("")
+    qa_5: str = Form("")
 
 
 @dataclass


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
- 사용자페이지에서 html태그를 추가하는 것만으로도 여분필드를 사용할 수 있도록 수정
-  formclass.py > 게시판, Q&A의 여분필드 속성 값 추가

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
- #460

## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
- https://sir.kr/qa/525894