### PR TITLE
fix: 카카오 로그인 client_secret 키 설정시 오류 수정

### DIFF
--- a/lib/social/providers/kakao.py
+++ b/lib/social/providers/kakao.py
@@ -26,7 +26,10 @@ class Kakao(SocialProvider):
             access_token_params=None,
             authorize_url="https://kauth.kakao.com/oauth/authorize",
             authorize_params=None,
-            client_kwargs={"scope": "account_email, profile_image"},
+            client_kwargs={
+                "scope": "account_email, profile_image",
+                "token_endpoint_auth_method": "client_secret_post"
+            },
             api_base_url="https://kapi.kakao.com/v2/user/me",
             # api_base_url="https://kapi.kakao.com/v2/user/me?property_keys=['kakao_account.profile', 'kakao_account.email']",
         )

--- a/lib/social/social.py
+++ b/lib/social/social.py
@@ -18,7 +18,7 @@ def register_social_provider(config: Config):
     Args:
         config (Config): 기본환경설정 객체
     Examples:
-        서버 재시작 후 인증 객체가 등록되지 않아서 등록에 사용.
+        서버 재시작 후 인증 객체가 등록되지 않아서 사용.
     """
     if not config.cf_social_login_use:
         return
@@ -35,7 +35,7 @@ def register_social_provider(config: Config):
                 provider_class.register(oauth, config.cf_naver_clientid.strip(), config.cf_naver_secret.strip())
 
         elif provider_name == 'kakao':
-            if not config.cf_kakao_rest_key:
+            if config.cf_kakao_rest_key:
                 # 카카오 client_secret 은 선택사항
                 provider_class.register(oauth, config.cf_kakao_rest_key.strip(), config.cf_kakao_client_secret.strip())
 


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [ ] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [ ] 테스트가 성공적으로 수행되었는지 확인했습니다.


## PR 유형
어떤 유형의 PR인가요? (해당 항목에 모두 체크해주세요)

<!-- 괄호 안에 "x"를 입력해서 어떤 유형인지 체크합니다: [x] -->

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] UI/UX 개선
- [ ] 문서내용 수정
- [ ] 코드 의미에 영향을 주지 않는 변경사항 (오타, 서식 지정, 변수명 변경 등)
- [ ] 코드 리팩토링 (버그 수정이나 기능 변경 없는 코드 변경)
- [ ] 빌드 관련 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (이유를 설명해주세요.)


## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
* 카카오 client_secret 키 설정시 오류 수정 - 카카오 콘솔에서 시크릿키 활성화시 Bad Client Credentials 오류 발생

* 서버 재시작 할 때 카카오 모듈 로딩 오류 수정

## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->
