### PR TITLE
게시물 이동 코멘트 변수 초기화

### DIFF
--- a/bbs/board.py
+++ b/bbs/board.py
@@ -323,6 +323,7 @@ async def move_update(
             target_write_model = dynamic_create_write_table(target_bo_table)
             target_write = target_write_model()
 
+            log_msg = ""
             # 복사/이동 로그 기록
             if not origin_write.wr_is_comment and config.cf_use_copy_log:
                 nick = cut_name(request, member.mb_nick)


### PR DESCRIPTION
관리자 화면에서 '게시물 아래에 누구로 부터 복사, 이동됨 표시' 옵션을 해제한 상태로 게시물 복사/이동시 log_msg 변수가 초기화되어 있지 않아서 다음과 같은 오류 발생하여 빈 문자열로 초기화 코드 추가

target_write.wr_content = origin_write.wr_content + log_msg
                                                                                    ^^^^^^^
UnboundLocalError: cannot access local variable 'log_msg' where it is not associated with a value