### PR TITLE
[fix] REST API > 댓글 관련 오류 수정 / 누락된 기능 추가

### DIFF
--- a/api/v1/models/board.py
+++ b/api/v1/models/board.py
@@ -87,6 +87,7 @@ class ResponseCommentModel(BaseModel):
     wr_option: str
     wr_email: str
     wr_comment: int
+    wr_comment_reply: str
     is_reply: bool
     is_edit: bool
     is_del: bool

--- a/api/v1/routers/board.py
+++ b/api/v1/routers/board.py
@@ -379,7 +379,6 @@ async def api_create_comment(
     - **wr_name**: 작성자 이름 (비회원일 경우)
     - **wr_password**: 비밀번호
     - **wr_option**: 글 옵션
-    - **wr_id**: 부모글 ID
     - **comment_id**" 댓글 ID (대댓글 작성시 댓글 id)
     wr_id만 입력 - 댓글작성
     wr_id, comment_id 입력 - 대댓글 작성


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
- 댓글 생성 REST API에 대한 documentation 설명 중, request body에 포함되지 않는 wr_id에 대한 설명을 삭제했습니다.
- 댓글 정보를 불러오는 대댓글 표시를 위해 API response에 wr_comment_reply 키를 추가했습니다.


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.