### PR TITLE
[fix] #617 REST API > 게시판 조회 - 게시글 페이지당 목록수 수정

### DIFF
--- a/api/v1/models/board.py
+++ b/api/v1/models/board.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated, List, Union
 from fastapi import Body, Path, Query
 from pydantic import BaseModel, ConfigDict, model_validator, Field
 
-from api.v1.models.pagination import PaginationResponse
+from api.v1.models.pagination import PaginationResponse, PagenationRequest
 
 
 class WriteModel(BaseModel):
@@ -271,6 +271,21 @@ class ResponseBoardModel(BaseModel):
     # bo_8: str
     # bo_9: str
     # bo_10: str
+
+
+class BoardPaginationRequest(PagenationRequest):
+    per_page: int = Field(
+        Query(default=0,
+              ge=0,
+              le=100,
+              title="출력 수",
+              description="""페이지 당 결과 수 <br>\
+                최대 100 <br>\
+                0인 경우 개별 게시판 설정을 따르고 <br>\
+                개별 게시판 설정도 0인 경우 기본 설정의 값을 따름
+              """
+              )
+    )
 
 
 class ResponseBoardListModel(PaginationResponse):

--- a/api/v1/routers/board.py
+++ b/api/v1/routers/board.py
@@ -17,7 +17,7 @@ from api.v1.models.board import (
     ResponseBoardListModel, ResponseNormalModel, ResponseCreateWriteModel,
     CommentUpdateModel
 )
-from api.v1.models.pagination import PagenationRequest
+from api.v1.models.board import BoardPaginationRequest
 from api.v1.service.board import (
     ListPostServiceAPI, ReadPostServiceAPI,
     CreatePostServiceAPI, UpdatePostServiceAPI, DownloadFileServiceAPI,
@@ -43,11 +43,13 @@ credentials_exception = HTTPException(
             )
 async def api_list_post(
     service: Annotated[ListPostServiceAPI, Depends(ListPostServiceAPI.async_init)],
-    pagination: Annotated[PagenationRequest, Depends()]
+    pagination: Annotated[BoardPaginationRequest, Depends()]
 ) -> ResponseBoardListModel:
     """
     게시판 정보, 글 목록을 반환합니다.
     """
+    per_page = service.get_board_per_page(pagination.per_page)
+
     writes = service.get_writes(
         with_files=True,
         page=pagination.page,
@@ -55,7 +57,7 @@ async def api_list_post(
     )
     total_records = service.get_total_count()
     paging_info = get_paging_info(
-        pagination.page, pagination.per_page, total_records
+        pagination.page, per_page, total_records
     )
     content = {
         "total_records": total_records,

--- a/service/board/board.py
+++ b/service/board/board.py
@@ -156,6 +156,15 @@ class BoardService(BaseService, BoardConfig):
 
         return write
 
+    def get_board_per_page(self, per_page = 0):
+        """게시판별 페이지당 게시글 수를 가져온다."""
+        if per_page != 0:
+            return per_page
+        if self.board.bo_page_rows != 0:
+            return self.board.bo_page_rows  # 게시판 설정에서 페이지당 게시글 수를 사용
+        else:
+            return self.config.cf_page_rows # 상위 클래스(BoardConfig)에서 설정한 페이지당 게시글 수를 사용
+
     def get_parent_post(self, parent_id: int, is_reply: bool = True):
         """부모글 호출"""
         if not parent_id:


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
REST API 게시판 조회시 게시글 페이지당 출력의 목록수(per_page )를 0으로 할 시에,
개별 게시판 또는 전체 게시판 출력 목록수 설정값을 따르도록 설정


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
#617 


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.