### PR TITLE
[fix] 자동저장글 호출/저장시 타인 글에 대한 접근 오류 수정

### DIFF
--- a/service/ajax/ajax.py
+++ b/service/ajax/ajax.py
@@ -157,7 +157,7 @@ class AJAXService:
         if not save_data:
             raise JSONException(status_code=404, message="저장된 글이 없습니다.")
         if save_data.mb_id != member.mb_id:
-            raise JSONException(status_code=403, detail="접근 권한이 없습니다.")
+            raise JSONException(status_code=403, message="접근 권한이 없습니다.")
         return save_data
 
     def get_autosave_count(self, mb_id: str) -> int:

--- a/service/ajax/ajax.py
+++ b/service/ajax/ajax.py
@@ -174,10 +174,11 @@ class AJAXService:
             data.as_uid = get_unique_id(self.request)
 
         save_data = self.db.scalar(
-            select(AutoSave)
-            .where(AutoSave.mb_id == member.mb_id, AutoSave.as_uid == data.as_uid)
+            select(AutoSave).where(AutoSave.as_uid == data.as_uid)
         )
         if save_data:
+            if save_data.mb_id != member.mb_id:
+                raise JSONException(status_code=403, message="접근 권한이 없습니다.")
             save_data.as_subject = data.as_subject
             save_data.as_content = data.as_content
             save_data.as_datetime = datetime.now()


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
- response json Key 오류 수정
- as_uid 값만으로 row 탐색 후 mb_id 검증


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
#622


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.