### PR TITLE
[fix] #624 REST API > 최근 게시물 목록 출력 양식 수정

### DIFF
--- a/api/v1/models/board.py
+++ b/api/v1/models/board.py
@@ -284,6 +284,14 @@ class ResponseBoardListModel(PaginationResponse):
     next_spt: Union[int, None]
 
 
+class ResponseTotalBoardNewListModel(BaseModel):
+    """최신글 목록 모델"""
+    free: List[ResponseWriteModel]
+    gallery: List[ResponseWriteModel]
+    qa: List[ResponseWriteModel]
+    notice: List[ResponseWriteModel]
+
+
 class ResponseGroupModel(BaseModel):
     """게시판 그룹 모델"""
     gr_id: str

--- a/api/v1/routers/board_new.py
+++ b/api/v1/routers/board_new.py
@@ -10,7 +10,9 @@ from lib.board_lib import get_bo_table_list
 from api.v1.dependencies.member import get_current_member
 from api.v1.models.response import response_401, response_422
 from api.v1.models.board import (
-    BoardNewViewType, RequestBoardNewWrites, ResponseNormalModel, ResponseBoardNewListModel
+    BoardNewViewType, RequestBoardNewWrites, ResponseNormalModel,
+    ResponseBoardNewListModel, ResponseTotalBoardNewListModel,
+    ResponseWriteModel
 )
 from lib.common import get_paging_info
 from service.board_new import BoardNewServiceAPI
@@ -57,7 +59,7 @@ async def api_board_new_list(
 async def api_latest_posts(
     service: Annotated[BoardNewServiceAPI, Depends()],
     data: RequestBoardNewWrites = Depends(),
-):
+) -> ResponseTotalBoardNewListModel:
     """
     모든 게시판의 최신글을 조회합니다.
     """
@@ -74,12 +76,12 @@ async def api_latest_posts_by_board(
     service: Annotated[BoardNewServiceAPI, Depends()],
     bo_table: Annotated[str, Path(..., title="게시판 코드", description="게시판 코드")],
     data: RequestBoardNewWrites = Depends(),
-):
+) -> List[ResponseWriteModel]:
     """
     최신글을 게시판별로 조회합니다.
     """
     latest_posts = service.get_latest_posts([bo_table], data.view_type.value, data.rows)
-    return latest_posts
+    return latest_posts[bo_table]
 
 
 @router.post("/delete",

--- a/service/board_new/board_new.py
+++ b/service/board_new/board_new.py
@@ -9,8 +9,10 @@ from core.exception import AlertException
 from lib.common import dynamic_create_write_table, cut_name, FileCache
 from lib.board_lib import BoardConfig, get_list, get_list_thumbnail
 from service import BaseService
+from service.ajax.ajax import AJAXService
 from service.board_file_service import BoardFileService
 from service.point_service import PointService
+from api.v1.service.member import MemberImageServiceAPI
 
 
 class BoardNewService(BaseService):
@@ -143,6 +145,16 @@ class BoardNewService(BaseService):
                 write.images, write.normal_files = self.file_service.get_board_files_by_type(bo_table, write.wr_id)
                 # 썸네일 이미지 설정
                 write.thumbnail = get_list_thumbnail(request, board, write, board_config.gallery_width, board_config.gallery_height)
+
+                # 회원 이미지, 아이콘 경로 설정
+                write.mb_image_path = MemberImageServiceAPI.get_image_path(write.mb_id)
+                write.mb_icon_path = MemberImageServiceAPI.get_icon_path(write.mb_id)
+
+                # 게시글 좋아요/싫어요 정보 설정
+                ajax_good_data = AJAXService(self.request, self.db).get_ajax_good_data(bo_table, write)
+                write.good = ajax_good_data["good"]
+                write.nogood = ajax_good_data["nogood"]
+
             boards_info[bo_table] = writes
 
         return boards_info


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## 변경 사항
<!-- 변경되는 사항과 작성한 코드에 대한 이유를 자세히 설명해주세요. -->
- Response Model 적용 출력 json key 제한 (#624 wr_password 제거)
- 개별글 정보: 게시판 목록과 같은 양식으로 출력
- mb_image, mb_icon, good, nogood 정보 출력


## 관련 이슈
<!-- 해당하는 이슈가 존재할 경우, 이슈번호 또는 이슈에 대한 링크를 추가하세요: #(Isuue Number) -->
#624


## 기타 정보
<!-- 추가적으로 전달하고 싶은 정보가 있다면 여기에 적어주세요. -->


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.