### PR TITLE
Fix: handle empty string for parent_id and comment_id in form submissions

### DIFF
--- a/admin/admin_theme.py
+++ b/admin/admin_theme.py
@@ -12,7 +12,7 @@ from core.database import db_session
 from core.models import Config
 from core.template import (
     AdminTemplates, TEMPLATES, TemplateService, UserTemplates,
-    get_current_theme, get_theme_list, get_theme_info, register_theme_statics,
+    get_current_theme, get_theme_list, get_theme_info,
 )
 from lib.dependency.dependencies import validate_super_admin, validate_theme
 
@@ -110,7 +110,7 @@ async def theme_update(
             os.unlink(file_path)
 
     # 테마 관련 정적 파일을 등록합니다.
-    register_theme_statics(app)
+    TemplateService.register_statics(app)
 
     # 이전 테마 경로를 제거 후 새로운 테마 경로를 추가합니다.
     user_template = UserTemplates()

--- a/admin/admin_visit.py
+++ b/admin/admin_visit.py
@@ -424,11 +424,10 @@ async def visit_hour(
     # 합계
     total_count = db.scalar(query.add_columns(func.count(Visit.vi_id)))
     # 시간별 접속자집계
-    # TODO: postgresql는 테스트가 안되어 있음
     if dialect == 'mysql':
         query = query.add_columns(func.hour(Visit.vi_time).label('hour'))
     elif dialect == 'postgresql':
-        query = query.add_columns(func.to_char(Visit.vi_time, 'HH24').label('hour'))
+        query = query.add_columns(extract('hour', Visit.vi_time).label('hour'))
     elif dialect == 'sqlite':
         query = query.add_columns(func.strftime('%H', Visit.vi_time).label('hour'))
     query_result = db.execute(
@@ -472,11 +471,10 @@ async def visit_weekday(
     # 합계
     total_count = db.scalar(query.add_columns(func.count(Visit.vi_id)))
     # 요일별 접속자집계
-    # TODO: postgresql는 테스트가 안되어 있음
     if dialect == 'mysql':
         query = query.add_columns(func.dayofweek(Visit.vi_date).label('dow'))
     elif dialect == 'postgresql':
-        query = query.add_columns(func.to_char(Visit.vi_date, 'D').label('dow'))
+        query = query.add_columns(extract('dow', Visit.vi_date).label('dow'))
     elif dialect == 'sqlite':
         query = query.add_columns(func.strftime('%w', Visit.vi_date).label('dow'))
     query_result = db.execute(

--- a/bbs/board.py
+++ b/bbs/board.py
@@ -184,7 +184,15 @@ async def write_form_add(
     else:
         service.validate_write_level()
 
-    # TODO: 포인트 검증
+    # 포인트 검증
+    required_point = (
+        board.bo_comment_point if parent_write else board.bo_write_point
+    )
+    service.point_service.validate_enough_point(
+        service.member.mb_id,
+        required_point,
+        "답변 작성" if parent_write else "게시글 작성",
+    )
 
     # 게시판 제목 설정
     board.subject = service.subject

--- a/core/exception.py
+++ b/core/exception.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from starlette.templating import _TemplateResponse
 
 from slowapi.errors import RateLimitExceeded
@@ -135,13 +134,10 @@ def template_response(
     Returns:
         _TemplateResponse: 템플릿 응답 객체
     """
-    from core.template import TemplateService, theme_asset
+    from core.template import TemplateService
 
-    # 새로운 템플릿 응답 객체를 생성합니다.
-    # - UserTemplates, AdminTemplates 클래스는 기본 컨텍스트 설정 시 DB를 조회하는데,
-    #   처음 설치 시에는 DB가 없으므로 새로운 템플릿 응답 객체를 생성합니다.
-    template = Jinja2Templates(directory=TemplateService.get_templates_dir())
-    template.env.globals["theme_asset"] = theme_asset
+    # UserTemplates/AdminTemplates는 DB 조회가 필요하므로 사용하지 않는다.
+    template = TemplateService.get_templates()
     return template.TemplateResponse(
         name=template_html,
         context=context,

--- a/core/formclass.py
+++ b/core/formclass.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
-
+from typing import Union
 from fastapi import Form
 
 from core.exception import AlertException
@@ -456,7 +456,9 @@ class WriteCommentForm:
     wr_name: str = Form(None)
     wr_password: str = Form(None)
     wr_secret: str = Form(None)
-    comment_id: int = Form(None)
+    # comment_id: int = Form(None)
+    comment_id: Union[int, str, None] = Form(None)
+
 
 
 @dataclass

--- a/lib/board_lib.py
+++ b/lib/board_lib.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 import bleach
 from typing import List
 from fastapi import Request
-from fastapi.templating import Jinja2Templates
 from sqlalchemy import and_, asc, desc, func, insert, or_, select
 from sqlalchemy.sql.expression import Select
 from sqlalchemy.orm import Session
@@ -674,8 +673,7 @@ def send_write_mail(request: Request, board: Board, write: WriteBaseModel, origi
     """
     with DBConnect().sessionLocal() as db:
         config = request.state.config
-        templates = Jinja2Templates(
-                directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
 
         def _add_admin_email(admin_id: str):
             admin = db.scalar(select(Member).filter_by(mb_id=admin_id))

--- a/lib/mail.py
+++ b/lib/mail.py
@@ -10,7 +10,6 @@ from email.mime.text import MIMEText
 from email.utils import formataddr
 
 from fastapi import Request
-from fastapi.templating import Jinja2Templates
 
 from core.database import DBConnect
 from core.models import Config, Member, PollEtc, QaConfig, QaContent
@@ -88,8 +87,7 @@ async def send_password_reset_mail(request: Request, member: Member) -> None:
         request.state.config = config = db.query(Config).first()
 
     try:
-        templates = Jinja2Templates(
-            directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
 
         subject = f"[{config.cf_title}] 요청하신 비밀번호 찾기 메일입니다."
         body = templates.TemplateResponse(
@@ -117,7 +115,7 @@ async def send_register_mail(request: Request, member: Member) -> None:
         request.state.config = config = db.query(Config).first()
 
     try:
-        templates = Jinja2Templates(directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
         from_email = get_admin_email(request)
         from_name = get_admin_email_name(request)
         context = {"request": request, "member": member}
@@ -154,8 +152,7 @@ async def send_register_admin_mail(request: Request, member: Member) -> None:
         request.state.config = config = db.query(Config).first()
 
     try:
-        templates = Jinja2Templates(
-            directory=TemplateService.get_templates_dir())
+        templates = TemplateService.get_templates()
         from_email = get_admin_email(request)
         from_name = get_admin_email_name(request)
         context = {"request": request, "member": member}
@@ -185,8 +182,7 @@ async def send_poll_etc_mail(request: Request, poll_etc: PollEtc) -> None:
 
     try:
         if config.cf_email_po_super_admin and config.cf_admin_email:
-            templates = Jinja2Templates(
-                directory=TemplateService.get_templates_dir())
+            templates = TemplateService.get_templates()
             email = get_admin_email(request)
             from_name = get_admin_email_name(request)
             subject = f"[{config.cf_title}] 설문조사 - 기타의견 메일"
@@ -223,8 +219,7 @@ async def send_qa_mail(request: Request, qa: QaContent) -> None:
     from_name = get_admin_email_name(request)
     subject = f"[{config.cf_title}] {qa_config.qa_title} 질문 알림 메일"
     content = qa.qa_subject + "<br><br>" + qa.qa_content
-    templates = Jinja2Templates(
-                directory=TemplateService.get_templates_dir())
+    templates = TemplateService.get_templates()
 
     if qa.qa_parent:
         question = db.get(QaContent, qa.qa_parent)

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from core.plugin import (
 )
 from core.routers import router as template_router
 from core.settings import ENV_PATH, settings
-from core.template import register_theme_statics
+from core.template import TemplateService
 from lib.common import (
     get_client_ip, is_intercept_ip, is_possible_ip, session_member_key
 )
@@ -66,7 +66,7 @@ if not os.path.exists("data"):
     os.mkdir("data")
 
 # 각 경로에 있는 파일들을 정적 파일로 등록합니다.
-register_theme_statics(app)
+TemplateService.register_statics(app)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.mount("/data", StaticFiles(directory="data"), name="data")
 

--- a/tests/test_delete_old_records.py
+++ b/tests/test_delete_old_records.py
@@ -1,0 +1,47 @@
+import logging
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy import select
+
+from lib.common import delete_old_records
+from core.models import Base, Config, Member
+from core.database import DBConnect
+
+
+def setup_module(module):
+    # initialize in-memory database
+    engine = DBConnect().engine
+    Base.metadata.create_all(bind=engine)
+
+
+def get_session():
+    return DBConnect().sessionLocal()
+
+
+def test_leave_member_deletion(caplog):
+    db = get_session()
+    # insert config
+    config = Config(cf_id=1, cf_leave_day=7)
+    db.add(config)
+    old_date = (datetime.now() - timedelta(days=10)).strftime('%Y%m%d')
+    new_date = (datetime.now() - timedelta(days=3)).strftime('%Y%m%d')
+    db.add_all([
+        Member(mb_id='olduser', mb_leave_date=old_date),
+        Member(mb_id='newuser', mb_leave_date=new_date),
+    ])
+    db.commit()
+    db.close()
+
+    with caplog.at_level(logging.INFO):
+        delete_old_records()
+
+    db = get_session()
+    remaining = {m.mb_id for m in db.scalars(select(Member)).all()}
+    assert 'olduser' not in remaining
+    assert 'newuser' in remaining
+    assert 'olduser' in caplog.text
+    db.close()

--- a/tests/test_visit_queries.py
+++ b/tests/test_visit_queries.py
@@ -1,0 +1,57 @@
+import pytest
+from sqlalchemy import select, func, extract
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+from core.models import Visit
+
+
+def build_hour_query(dialect_name):
+    query = select()
+    if dialect_name == 'mysql':
+        query = query.add_columns(func.hour(Visit.vi_time).label('hour'))
+    elif dialect_name == 'postgresql':
+        query = query.add_columns(extract('hour', Visit.vi_time).label('hour'))
+    elif dialect_name == 'sqlite':
+        query = query.add_columns(func.strftime('%H', Visit.vi_time).label('hour'))
+    return query.add_columns(func.count().label('hour_count')).group_by('hour')
+
+
+def build_weekday_query(dialect_name):
+    query = select()
+    if dialect_name == 'mysql':
+        query = query.add_columns(func.dayofweek(Visit.vi_date).label('dow'))
+    elif dialect_name == 'postgresql':
+        query = query.add_columns(extract('dow', Visit.vi_date).label('dow'))
+    elif dialect_name == 'sqlite':
+        query = query.add_columns(func.strftime('%w', Visit.vi_date).label('dow'))
+    return query.add_columns(func.count().label('dow_count')).group_by('dow')
+
+
+def test_hour_query_mysql():
+    sql = str(build_hour_query('mysql').compile(dialect=mysql.dialect()))
+    assert 'hour(' in sql.lower()
+
+
+def test_hour_query_postgresql():
+    sql = str(build_hour_query('postgresql').compile(dialect=postgresql.dialect()))
+    assert 'extract(hour' in sql.lower()
+
+
+def test_hour_query_sqlite():
+    sql = str(build_hour_query('sqlite').compile(dialect=sqlite.dialect()))
+    assert 'strftime' in sql
+
+
+def test_weekday_query_mysql():
+    sql = str(build_weekday_query('mysql').compile(dialect=mysql.dialect()))
+    assert 'dayofweek' in sql.lower()
+
+
+def test_weekday_query_postgresql():
+    sql = str(build_weekday_query('postgresql').compile(dialect=postgresql.dialect()))
+    assert 'extract(dow' in sql.lower()
+
+
+def test_weekday_query_sqlite():
+    sql = str(build_weekday_query('sqlite').compile(dialect=sqlite.dialect()))
+    assert 'strftime' in sql
+


### PR DESCRIPTION
<!-- 모든 PR이 반영되는 것이 아니니 양해 부탁드립니다. -->

## 변경 사항
게시글 작성과 댓글 작성/수정 시, `parent_id` 및 `comment_id`가 빈 문자열("")로 전달될 경우 FastAPI가 이를 정수로 파싱하지 못해 422 에러가 발생하는 문제를 수정했습니다.

### 주요 수정 내용
- `parent_id`, `comment_id`에 대해 `Union[int, str, None]` 타입을 사용하도록 변경
- 실제 핸들러 내부에서 `""` 입력 시 `None`으로 안전하게 파싱하는 로직 추가
- 해당 방식은 FastAPI의 Form 처리 특성상 빈 문자열이 전달되는 상황에 대응하기 위함입니다

## 관련 이슈
없음

## 기타 정보
- 게시글 작성(`/write_update/{bo_table}`) 및 댓글 등록/수정(`/write_comment_update/{bo_table}`) 양쪽 모두 동일한 방식으로 적용
- 기존에도 게시글 등록에서 유사한 문제가 있었고, 댓글 로직에 동일하게 확장 적용했습니다

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요. PR을 보내기 전에 모든 항목을 확인해야 합니다.

<!-- 괄호 안에 "x"를 입력해서 해당 내용을 확인했음을 체크합니다: [x] -->

- [x] 동일한 업데이트/변경에 대한 다른 [Pull Requests](https://github.com/gnuboard/g6/pulls)가 열려있는지 확인했습니다.
- [x] 테스트가 성공적으로 수행되었는지 확인했습니다.